### PR TITLE
v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ The source code is available on [GitHub](https://github.com/thomaseleff/audera).
    ```
    pip install .
    ```
+
+## Roadmap
+Upcoming enhancements / fixes in priority order. Open an [issue](https://github.com/thomaseleff/audera/issues/new) to request a feature or fix.
+
+- [x] Access point Wi-Fi sharing
+- [ ] Digital sound processing (DSP)
+- [ ] Audera streamer (Bluetooth input-only)
+- [ ] Audera streamer Wi-Fi sharing setup
+- [ ] Audera streamer web-interface
+  - [ ] Managing players / player groups and playback sessions
+  - [ ] Streamer settings
+  - [ ] Danger zone OTT updates
+
+#### Misc. improvements
+- [ ] FLAC encoding / decoding with ffmpeg
+- [ ] Multi-player sync optimization
+- [ ] Event tracking (logins / sessions / errors, etc..)

--- a/audera/__init__.py
+++ b/audera/__init__.py
@@ -7,9 +7,9 @@ for DIY home audio enthusiasts.
 from typing import List
 import errno
 
-from audera import ap, netifaces, ntp, mdns, struct, dal, devices, sessions, logging
+from audera import platform, ap, netifaces, ntp, mdns, struct, dal, devices, sessions, logging
 
-__all__ = ['ap', 'netifaces', 'ntp', 'mdns', 'struct', 'dal', 'devices', 'sessions', 'logging']
+__all__ = ['platform', 'ap', 'netifaces', 'ntp', 'mdns', 'struct', 'dal', 'devices', 'sessions', 'logging']
 
 # Logo
 LOGO: List[str] = [

--- a/audera/__init__.py
+++ b/audera/__init__.py
@@ -1,6 +1,6 @@
 """ audera
 
-`audera` is an open-source multi-room audio streaming system written in Python
+🔮 `audera` is an open-source multi-room audio streaming system written in Python
 for DIY home audio enthusiasts.
 """
 
@@ -23,9 +23,13 @@ LOGO: List[str] = [
 ]
 NAME: str = 'audera'
 DESCRIPTION: str = ''.join([
-    '`audera` is an open-source multi-room audio streaming system written in',
+    '🔮 `audera` is an open-source multi-room audio streaming system written in',
     ' Python for DIY home audio enthusiasts.'
 ])
+
+# Websites
+HOME: str = 'https://github.com/thomaseleff/audera'
+DOCS: str = 'https://github.com/thomaseleff/audera/tree/main/docs'
 
 # Network configuration
 MDNS_TYPE = f"_{NAME.lower()}._tcp.local."

--- a/audera/__init__.py
+++ b/audera/__init__.py
@@ -7,9 +7,9 @@ for DIY home audio enthusiasts.
 from typing import List
 import errno
 
-from audera import netifaces, ntp, mdns, struct, dal, devices, sessions, logging
+from audera import ap, netifaces, ntp, mdns, struct, dal, devices, sessions, logging
 
-__all__ = ['netifaces', 'ntp', 'mdns', 'struct', 'dal', 'devices', 'sessions', 'logging']
+__all__ = ['ap', 'netifaces', 'ntp', 'mdns', 'struct', 'dal', 'devices', 'sessions', 'logging']
 
 # Logo
 LOGO: List[str] = [

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -1,16 +1,22 @@
 """ Access point management """
 
+from typing_extensions import Literal
 import subprocess
-from audera import struct, platform
+import time
+from audera import struct, platform, netifaces
 
 
 class AccessPoint():
-    """ A `class` that represents a wi-fi access point.
+    """ A `class` that represents a Wi-Fi access point.
 
     Parameters
     ----------
     name: `str`
         The name of the access-point.
+    url: `str`
+        The url web-address for accessing the access-point.
+    interface: `str`
+        The network interface for the access-point.
     identity: `audera.struct.identity.Identity`
         The `audera.struct.identity.Identity` containing the unique identity of the
             network device.
@@ -19,27 +25,35 @@ class AccessPoint():
     def __init__(
         self,
         name: str,
+        url: str,
+        interface: Literal['wlan0'],
         identity: struct.identity.Identity
     ):
-        """ Creates an instance of a wi-fi access point.
+        """ Creates an instance of a Wi-Fi access point.
 
         Parameters
         ----------
         name: `str`
             The name of the access-point.
+        url: `str`
+            The url web-address for accessing the access-point.
+        interface: `str`
+            The network interface for the access-point.
         identity: `audera.struct.identity.Identity`
             The `audera.struct.identity.Identity` containing the unique identity of the
                 network device.
         """
+        self.url = url.replace('https://', '').replace('http://')
+        self.interface = interface
         self.hostname = '-'.join([name.strip().lower(), identity.short_uuid])
 
     @platform.requires('dietpi')
     def start(self):
-        """ Starts a wi-fi access point for credential sharing. """
+        """ Starts a Wi-Fi access point for credential sharing. """
 
         # Configure hostapd
         with open("/etc/hostapd/hostapd.conf", "w") as f:
-            f.write("interface=wlan0\n")
+            f.write(f"interface={self.interface}\n")
             f.write("driver=nl80211\n")
             f.write(f"ssid={self.hostname}\n")
             f.write("hw_mode=g\n")
@@ -48,38 +62,97 @@ class AccessPoint():
             f.write("macaddr_acl=0\n")
             f.write("auth_algs=1\n")
             f.write("ignore_broadcast_ssid=0\n")
-            f.write("wpa=2\n")
-            f.write("rsn_pairwise=CCMP\n")
             f.write(f"hostname={self.hostname}\n")
 
-        # Enable hostapd
-        with open("/etc/default/hostapd", "a") as f:
+        # Update the hostapd service
+        with open("/etc/default/hostapd", "w") as f:
             f.write("DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"\n")
 
         # Start hostapd
         subprocess.run(["sudo", "systemctl", "unmask", "hostapd"], check=True)
-        subprocess.run(["sudo", "systemctl", "enable", "hostapd"], check=True)
-        subprocess.run(["sudo", "systemctl", "start", "hostapd"], check=True)
+        hostapd_result = subprocess.run(["sudo", "systemctl", "start", "hostapd"], check=True)
+
+        # Get the default interface ip-address
+        interface_address = netifaces.get_interface_ip_address(self.interface)
+
+        # Wait for the service
+        if hostapd_result.returncode == 0:
+
+            # Check the service, time-out if the service fails to start after 10 seconds
+            time_out = 0
+
+            while time_out < 10:
+                time.sleep(1)
+
+                if self.hostapd_is_active():
+                    break
+
+                time_out += 1
+
+            if not self.hostapd_is_active():
+                raise AccessPointError(
+                    'Unable to start the Wi-Fi access-point {%s} on interface {%s}.' % (
+                        self.hostname,
+                        self.interface
+                    )
+                )
 
         # Configure dnsmasq
-        with open("/etc/dnsmasq.conf", "a") as f:
-            f.write("interface=wlan0\n")
-            f.write("dhcp-range=192.168.4.2,192.168.4.20,255.255.255.0,24h\n")
-
-        # Enable dnsmasq
-        subprocess.run(["sudo", "systemctl", "enable", "dnsmasq"], check=True)
+        with open("/etc/dnsmasq.conf", "w") as f:
+            f.write(f"interface={self.interface}\n")
+            f.write(f"address=/{self.url}/{interface_address}")
 
         # Start dnsmasq
-        subprocess.run(["sudo", "systemctl", "restart", "dnsmasq"], check=True)
+        subprocess.run(["sudo", "systemctl", "unmask", "dnsmasq"], check=True)
+        dnsmasq_result = subprocess.run(["sudo", "systemctl", "start", "dnsmasq"], check=True)
+
+        # Wait for the service
+        if dnsmasq_result.returncode == 0:
+
+            # Check the service, time-out if the service fails to start after 10 seconds
+            time_out = 0
+
+            while time_out < 10:
+                time.sleep(1)
+
+                if self.dnsmasq_is_active():
+                    break
+
+                time_out += 1
+
+            if not self.dnsmasq_is_active():
+                raise AccessPointError(
+                    'Unable to start the DNS server to route traffic from {%s} to {%s} on interface {%s}.' % (
+                        'https://%s' % self.url,
+                        interface_address,
+                        self.interface
+                    )
+                )
 
     @platform.requires('dietpi')
-    def stop(self):
-        """ Stops a wi-fi access point. """
+    def stop():
+        """ Stops a Wi-Fi access point. """
 
-        subprocess.run(
-            ['nmcli', 'connection', 'delete', self.hostname],
+        subprocess.run(['sudo', 'systemctl', 'stop', 'hostapd'], check=True)
+        subprocess.run(['sudo', 'systemctl', 'stop', 'dnsmasq'], check=True)
+
+    @platform.requires('dietpi')
+    def hostapd_is_active() -> bool:
+        """ Returns the active status of the Wi-Fi access point. """
+
+        return True if subprocess.run(
+            ['sudo', 'systemctl', 'is-active', 'hostapd'],
             check=True
-        )
+        ).stdout.decode().strip() == 'active' else False
+
+    @platform.requires('dietpi')
+    def dnsmasq_is_active() -> bool:
+        """ Returns the active status of the local DNS server service. """
+
+        return True if subprocess.run(
+            ['sudo', 'systemctl', 'is-active', 'dnsmasq'],
+            check=True
+        ).stdout.decode().strip() == 'active' else False
 
 
 # Exception(s)

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -136,18 +136,20 @@ class AccessPoint():
                 )
 
     @platform.requires('dietpi')
-    def stop():
+    def stop(self):
         """ Stops a Wi-Fi access point. """
 
-        try:
-            subprocess.run(['sudo', 'systemctl', 'stop', 'hostapd'], check=True)
-        except subprocess.CalledProcessError as e:
-            raise AccessPointError("Failed to stop hostapd. %s" % e)
+        if self.hostapd_is_active():
+            try:
+                subprocess.run(['sudo', 'systemctl', 'stop', 'hostapd'], check=True)
+            except subprocess.CalledProcessError as e:
+                raise AccessPointError("Failed to stop hostapd. %s" % e)
 
-        try:
-            subprocess.run(['sudo', 'systemctl', 'stop', 'dnsmasq'], check=True)
-        except subprocess.CalledProcessError as e:
-            raise AccessPointError("Failed to stop dnsmasq. %s" % e)
+        if self.dnsmasq_is_active():
+            try:
+                subprocess.run(['sudo', 'systemctl', 'stop', 'dnsmasq'], check=True)
+            except subprocess.CalledProcessError as e:
+                raise AccessPointError("Failed to stop dnsmasq. %s" % e)
 
     @platform.requires('dietpi')
     def hostapd_is_active() -> bool:

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -3,7 +3,7 @@
 from typing_extensions import Literal
 import subprocess
 import time
-from audera import struct, platform, netifaces
+from audera import struct, platform
 
 
 class AccessPoint():
@@ -74,9 +74,6 @@ class AccessPoint():
         except subprocess.CalledProcessError as e:
             raise AccessPointError("Failed to start hostapd. %s" % e)
 
-        # Get the default interface ip-address
-        interface_address = netifaces.get_interface_ip_address(self.interface)
-
         # Wait for the service
         if hostapd_result.returncode == 0:
 
@@ -102,7 +99,7 @@ class AccessPoint():
         # Configure dnsmasq
         with open("/etc/dnsmasq.conf", "w") as f:
             f.write(f"interface={self.interface}\n")
-            f.write(f"address=/{self.url}/{interface_address}")
+            f.write(f"address=/{self.url}/127.0.0.1")
 
         # Start dnsmasq
         subprocess.run(["sudo", "systemctl", "unmask", "dnsmasq"], check=True)
@@ -127,9 +124,8 @@ class AccessPoint():
 
             if not self.dnsmasq_is_active():
                 raise AccessPointError(
-                    'Unable to start the DNS server to route traffic from {%s} to {%s} on interface {%s}.' % (
+                    'Unable to start the DNS server to route traffic from {%s} to {127.0.0.1} on interface {%s}.' % (
                         'https://%s' % self.url,
-                        interface_address,
                         self.interface
                     )
                 )

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -99,6 +99,7 @@ class AccessPoint():
         # Configure dnsmasq
         with open("/etc/dnsmasq.conf", "w") as f:
             f.write(f"interface={self.interface}\n")
+            f.write("dhcp-range=192.168.1.100,192.168.1.150,12h\n")
             f.write(f"address=/{self.url}/127.0.0.1")
 
         # Start dnsmasq

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -1,0 +1,63 @@
+""" Access point management """
+
+import subprocess
+import platform
+from audera import struct
+
+
+class AccessPoint():
+    """ A `class` that represents a wi-fi access point.
+
+    Parameters
+    ----------
+    name: `str`
+        The name of the access-point.
+    identity: `audera.struct.identity.Identity`
+        The `audera.struct.identity.Identity` containing the unique identity of the
+            network device.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        identity: struct.identity.Identity
+    ):
+        """ Creates an instance of a wi-fi access point.
+
+        Parameters
+        ----------
+        name: `str`
+            The name of the access-point.
+        identity: `audera.struct.identity.Identity`
+            The `audera.struct.identity.Identity` containing the unique identity of the
+                network device.
+        """
+        self.hostname = '-'.join([name.strip().lower(), identity.short_uuid])
+        self.os = platform.system()
+
+    def start(self):
+        """ Starts a wi-fi access point for credential sharing. """
+
+        if self.os == 'Linux':
+            subprocess.run(
+                ['nmcli', 'device', 'wifi', 'hotspot', 'ifname', 'wlan0', 'con-name', self.hostname, 'ssid', self.hostname],
+                check=True
+            )
+        else:
+            raise AccessPointError()
+
+    def stop(self) -> subprocess.CompletedProcess:
+        """ Stops a wi-fi access point. """
+
+        if self.os == 'Linux':
+            subprocess.run(
+                ['nmcli', 'connection', 'delete', self.hostname],
+                check=True
+            )
+        else:
+            raise AccessPointError()
+
+
+# Exception(s)
+class AccessPointError(Exception):
+    pass

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -1,8 +1,7 @@
 """ Access point management """
 
 import subprocess
-import platform
-from audera import struct
+from audera import struct, platform
 
 
 class AccessPoint():
@@ -33,31 +32,27 @@ class AccessPoint():
                 network device.
         """
         self.hostname = '-'.join([name.strip().lower(), identity.short_uuid])
-        self.os = platform.system()
 
+    @platform.requires('dietpi')
     def start(self):
         """ Starts a wi-fi access point for credential sharing. """
 
-        if self.os == 'Linux':
-            subprocess.run(
-                ['nmcli', 'device', 'wifi', 'hotspot', 'ifname', 'wlan0', 'con-name', self.hostname, 'ssid', self.hostname],
-                check=True
-            )
-        else:
-            raise AccessPointError()
+        subprocess.run(
+            ['nmcli', 'device', 'wifi', 'hotspot', 'ifname', 'wlan0', 'con-name', self.hostname, 'ssid', self.hostname],
+            check=True
+        )
 
-    def stop(self) -> subprocess.CompletedProcess:
+    @platform.requires('dietpi')
+    def stop(self):
         """ Stops a wi-fi access point. """
 
-        if self.os == 'Linux':
-            subprocess.run(
-                ['nmcli', 'connection', 'delete', self.hostname],
-                check=True
-            )
-        else:
-            raise AccessPointError()
+        subprocess.run(
+            ['nmcli', 'connection', 'delete', self.hostname],
+            check=True
+        )
 
 
 # Exception(s)
 class AccessPointError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -3,7 +3,7 @@
 from typing_extensions import Literal
 import subprocess
 import time
-from audera import struct, platform
+from audera import struct, platform, netifaces
 
 
 class AccessPoint():
@@ -68,11 +68,11 @@ class AccessPoint():
 
         # Configure the access point interface
         subprocess.run(
-            ["iw", "dev", self.interface, "interface", "add", self.ap_interface, "type", "__ap"],
+            ["iw", "dev", f"{self.interface}", "interface", "add", f"{self.ap_interface}", "type", "__ap"],
             check=True
         )
         subprocess.run(
-            ["ip", "link", "set", self.ap_interface, "up"],
+            ["ip", "link", "set", f"{self.ap_interface}", "up"],
             check=True
         )
 
@@ -102,7 +102,7 @@ class AccessPoint():
                 [
                     "nmcli", "connection", "add",
                     "type", "wifi",
-                    "ifname", self.ap_interface,
+                    "ifname", f"{self.ap_interface}",
                     "con-name", f"{self.hostname}",
                     "autoconnect", "no",
                     "ssid", f"{self.hostname}",
@@ -152,7 +152,7 @@ class AccessPoint():
         """ Resumes the Wi-Fi access point. """
         try:
             subprocess.run(
-                ["nmcli", "connection", "up", self.hostname],
+                ["nmcli", "connection", "up", f"{self.hostname}"],
                 check=True
             )
         except subprocess.CalledProcessError:
@@ -169,7 +169,7 @@ class AccessPoint():
         if self.connection_exists():
             try:
                 subprocess.run(
-                    ["nmcli", "connection", "down", self.hostname],
+                    ["nmcli", "connection", "down", f"{self.hostname}"],
                     check=True
                 )
             except subprocess.CalledProcessError:
@@ -183,16 +183,7 @@ class AccessPoint():
     @platform.requires('dietpi')
     def connection_exists(self) -> bool:
         """ Returns whether the network-manager connection exists. """
-        try:
-            subprocess.run(
-                ["nmcli", "connection", "show", self.hostname],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL
-            )
-            return True
-        except subprocess.CalledProcessError:
-            return False
+        return netifaces.connection_exists(con_name=self.hostname)
 
 
 # Exception(s)

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -61,7 +61,7 @@ class AccessPoint():
             f.write("dhcp-range=10.42.0.10,10.42.0.100,12h\n")
             f.write("dhcp-option=3,10.42.0.1\n")
             f.write("dhcp-option=6,10.42.0.1\n")
-            f.write(f"address=/{self.url}/127.0.0.1")  # The default nicegui ip-address
+            f.write(f"address=/{self.url}/10.42.0.1")
 
         # Add the access point connection
         if not self.connection_exists():

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -62,7 +62,6 @@ class AccessPoint():
             f.write("macaddr_acl=0\n")
             f.write("auth_algs=1\n")
             f.write("ignore_broadcast_ssid=0\n")
-            f.write(f"hostname={self.hostname}\n")
 
         # Update the hostapd service
         with open("/etc/default/hostapd", "w") as f:

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -113,8 +113,7 @@ class AccessPoint():
                     "ipv4.addresses", "10.42.0.1/24",
                     "ipv4.gateway", "10.42.0.1",
                     "ipv6.method", "ignore"
-                ],
-                check=True
+                ]
             )
 
             # Wait for the service

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -24,6 +24,7 @@ class AccessPoint():
         The network interface for the access point.
     """
 
+    @platform.requires('dietpi')
     def __init__(
         self,
         name: str,
@@ -56,6 +57,18 @@ class AccessPoint():
     @platform.requires('dietpi')
     def start(self):
         """ Starts a Wi-Fi access point for credential sharing. """
+        self.create()
+        self.up()
+
+    @platform.requires('dietpi')
+    def stop(self):
+        """ Stops a Wi-Fi access point. """
+        self.down()
+        self.delete()
+
+    @platform.requires('dietpi')
+    def create(self):
+        """ Creates the Wi-Fi access point connection. """
 
         # Stop network-manager
         try:
@@ -138,13 +151,22 @@ class AccessPoint():
                         )
                     )
 
-        # Start the access point
-        self.up()
-
     @platform.requires('dietpi')
-    def stop(self):
-        """ Stops a Wi-Fi access point. """
-        self.down()
+    def delete(self):
+        """ Delets the Wi-Fi access point connection. """
+        if self.connection_exists():
+            try:
+                subprocess.run(
+                    ["nmcli", "connection", "delete", f"{self.hostname}"],
+                    check=True
+                )
+            except subprocess.CalledProcessError:
+                raise AccessPointError(
+                    'Unable to delete the Wi-Fi access point {%s} on interface {%s}.' % (
+                        self.hostname,
+                        self.ap_interface
+                    )
+                )
 
     @platform.requires('dietpi')
     def up(self):

--- a/audera/ap.py
+++ b/audera/ap.py
@@ -148,7 +148,7 @@ class AccessPoint():
                 raise AccessPointError("Failed to stop dnsmasq. %s" % e)
 
     @platform.requires('dietpi')
-    def hostapd_is_active() -> bool:
+    def hostapd_is_active(self) -> bool:
         """ Returns the active status of the Wi-Fi access point. """
         try:
             result = subprocess.run(
@@ -161,7 +161,7 @@ class AccessPoint():
             return False
 
     @platform.requires('dietpi')
-    def dnsmasq_is_active() -> bool:
+    def dnsmasq_is_active(self) -> bool:
         """ Returns the active status of the local DNS server service. """
 
         try:

--- a/audera/cli/commands.py
+++ b/audera/cli/commands.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 import asyncio
-from audera import player, streamer
+from audera import player, streamer, ui, netifaces
 
 
 # Define audera sub-command function(s)
@@ -44,6 +44,10 @@ def run(
         service = streamer.Service()
 
     if type_.strip().lower() == 'player':
+
+        # Initialize the remote audio output player setup
+        if not netifaces.connected():
+            ui.player.setup.run()
 
         # Initialize the remote audio output player service
         service = player.Service()

--- a/audera/dal/identities.py
+++ b/audera/dal/identities.py
@@ -140,7 +140,7 @@ def update(new: identity.Identity) -> identity.Identity:
             }
         )
 
-        return new
+        return identity.Identity.from_config(config=config_)
 
     else:
         return identity_
@@ -171,7 +171,7 @@ def get_identity_mac_address() -> str:
     return identity_.mac_address
 
 
-def get_identity_ip_address(uuid: str) -> str:
+def get_identity_ip_address() -> str:
     """ Returns the ip-address of the remote audio device as an `str`. """
 
     # Read the configuration file

--- a/audera/dal/identities.py
+++ b/audera/dal/identities.py
@@ -133,7 +133,7 @@ def update(new: identity.Identity) -> identity.Identity:
             {
                 'identity': {
                     'name': identity_.name,  # Retain the existing name, name is immutable
-                    'uuid': new.uuid,
+                    'uuid': identity_.uuid,  # Retain the existing uuid, uuid is immutable
                     'mac_address': new.mac_address,
                     'address': new.address
                 }

--- a/audera/dal/players.py
+++ b/audera/dal/players.py
@@ -168,11 +168,42 @@ def update(new: player.Player) -> player.Player:
 
         # Update the player configuration object and write to the configuration file
         config_ = config_.from_dict({'player': new.to_dict()})
-
         return new
 
     else:
         return player_
+
+
+def update_identity(identity_: identity.Identity) -> player.Player:
+    """ Updates the player configuration file `~/.audera/players/{player.uuid}.json`.
+
+    Parameters
+    ----------
+    identity_: `audera.struct.identity.Identity`
+        An instance of an `audera.struct.identity.Identity` object.
+    """
+
+    # Read the configuration file
+    config_ = get_or_create(identity_)
+
+    # Convert the config to an audio player object
+    player_: player.Player = player.Player.from_config(config=config_)
+
+    # Compare and update
+    if not identity.Identity(
+        name=player_.name,
+        uuid=player_.uuid,
+        mac_address=player_.uuid,
+        address=player_.address
+     ) == identity_:
+
+        # Update the player configuration object and write to the configuration file
+        player_.mac_address = identity_.mac_address
+        player_.address = identity_.address
+
+        config_ = config_.from_dict({'player': player_.to_dict()})
+
+    return player_
 
 
 def delete(uuid: str):

--- a/audera/dal/players.py
+++ b/audera/dal/players.py
@@ -322,19 +322,36 @@ def disconnect(uuid: str) -> player.Player:
     return update(player_)
 
 
-def update_volume(uuid: str, volume: float) -> player.Player:
+def update_player_name(player_: player.Player, name: str) -> player.Player:
+    """ Updates the name of a player by setting `name` = {name}.
+
+    Parameters
+    ----------
+    player_: `audera.struct.player.Player`
+        An instance of an `audera.struct.player.Player` object.
+    name: `str`
+        The name of the player.
+    """
+
+    if player_.name == name:
+        return player_
+
+    player_.name = utils.as_type(name, 'str')
+
+    return update(player_)
+
+
+def update_player_volume(player_: player.Player, volume: float) -> player.Player:
     """ Updates the volume for a player by setting `volume` = {volume}.
 
     Parameters
     ----------
-    uuid: `str`
-        A unique universal identifier of an `audera.struct.player.Player` object.
+    player_: `audera.struct.player.Player`
+        An instance of an `audera.struct.player.Player` object.
     volume: `float`
         A float value from 0 to 100 that sets the loudness of playback. A value of
             0 is muted.
     """
-
-    player_ = get_player(uuid)
 
     if player_.volume == volume:
         return player_
@@ -343,16 +360,16 @@ def update_volume(uuid: str, volume: float) -> player.Player:
     return update(player_)
 
 
-def update_channels(uuid: str, channels: int) -> player.Player:
+def update_player_channels(player_: player.Player, channels: int) -> player.Player:
     """ Updates the playback channels for a player by setting `channels` = {channels}.
 
     Parameters
     ----------
-    uuid: `str`
-        A unique universal identifier of an `audera.struct.player.Player` object.
+    player_: `audera.struct.player.Player`
+        An instance of an `audera.struct.player.Player` object.
+    channels: `int`
+        Either `1` for mono or `2` for stereo audio playback.
     """
-
-    player_ = get_player(uuid)
 
     if player_.channels == channels:
         return player_

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -6,7 +6,8 @@ import socket
 import netifaces
 import uuid
 import subprocess
-import platform
+
+from audera import platform
 
 
 def get_gateway_ip_address():
@@ -31,16 +32,14 @@ def connected() -> bool:
         socket.gethostbyname("www.cloudflare.com")
 
         # Ping Cloudflare DNS to check for internet access
-        os_name = platform.system()
-
-        if os_name == 'Linux' or os_name == 'Darwin':  # macOS and Linux
+        if platform.NAME in ['dietpi', 'linux', 'darwin']:
             result = subprocess.run(['ping', '-c', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode == 0:
                 return True
             else:
                 return False
 
-        elif os_name == 'Windows':
+        elif platform.NAME == 'windows':
             result = subprocess.run(['ping', '-n', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode == 0:
                 return True
@@ -67,6 +66,7 @@ def get_local_ip_address() -> str:
         raise NetworkConnectionError('Unable to determine the local ip-address.')
 
 
+@platform.requires('dietpi')
 async def connect(
     ssid: str,
     password: Union[str, None]
@@ -82,9 +82,6 @@ async def connect(
     """
     if not ssid:
         raise NetworkConnectionError('Invalid value. {ssid} cannot be empty.')
-
-    if platform.system() in ['Windows', 'Darwin']:
-        raise OSError('Invalid platform. Network setup is only available on Linux.')
 
     if password:
         result = subprocess.run(
@@ -125,16 +122,20 @@ async def connect(
 
 # Exception(s)
 class NetworkConnectionError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class NetworkTimeoutError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class NetworkNotFoundError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class InternetConnectionError(Exception):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -132,12 +132,12 @@ async def connect(
         while time_out < 10:
             await asyncio.sleep(1)
 
-            if connected():
+            if connected(interface):
                 break
 
             time_out += 1
 
-        if not connected():
+        if not connected(interface):
             raise InternetConnectionError('{%s} has no internet.' % ssid)
 
     elif result.returncode == 3:

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -37,7 +37,7 @@ def get_local_mac_address() -> str:
     return str(mac)
 
 
-def connected(interface: Literal['wlan0']) -> bool:
+def connected(interface: Literal['wlan0'] = 'wlan0') -> bool:
     """ Returns `True` when the network device is connected to the internet.
 
     Parameters

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -53,7 +53,7 @@ def connected(interface: Literal['wlan0'] = 'wlan0') -> bool:
         # Ping Cloudflare DNS to check for internet access
         if platform.NAME in ['dietpi', 'linux', 'darwin']:
             result = subprocess.run(
-                ['ping', '-c', '1', '-I', interface, '1.1.1.1'],
+                ['ping', '-c', '3', '-I', interface, '1.1.1.1'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE
             )
@@ -64,7 +64,7 @@ def connected(interface: Literal['wlan0'] = 'wlan0') -> bool:
 
         elif platform.NAME == 'windows':
             result = subprocess.run(
-                ['ping', '-n', '1', '1.1.1.1'],
+                ['ping', '-n', '3', '1.1.1.1'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE
             )
@@ -105,9 +105,9 @@ async def connect(
     ----------
     ssid: `str`
         The name of the Wi-Fi network.
-    password: `str`
+    password: `Union[str, None]`
         The password of the Wi-Fi network.
-    interface: `str`
+    interface: `Literal['wlan0']`
         The network interface for Wi-Fi connections.
     """
     if not ssid:
@@ -115,12 +115,23 @@ async def connect(
 
     if password:
         result = subprocess.run(
-            ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password, 'ifname', interface],
+            [
+                'nmcli', 'device', 'wifi',
+                'connect', ssid,
+                'password', password,
+                'ifname', interface,
+                "autoconnect", "yes"
+            ],
             check=True
         )
     else:
         result = subprocess.run(
-            ['nmcli', 'device', 'wifi', 'connect', ssid, 'ifname', interface],
+            [
+                'nmcli', 'device', 'wifi',
+                'connect', ssid,
+                'ifname', interface,
+                "autoconnect", "yes"
+            ],
             check=True
         )
 

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -3,6 +3,8 @@
 import socket
 import netifaces
 import uuid
+import subprocess
+import platform
 
 
 def get_gateway_ip_address():
@@ -12,19 +14,96 @@ def get_gateway_ip_address():
     return str(gateway_address)
 
 
-def get_local_ip_address() -> str:
-    """ Connects to an external ip-address, which determines the appropriate
-    interface for the connection, and then returns the local ip-address used
-    in that connection.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-        s.connect(("208.67.220.123", 80))  # DuckDuckGo
-        ip_address = s.getsockname()[0]
-    return str(ip_address)
-
-
 def get_local_mac_address() -> str:
     """ Returns the local hardware mac-address. """
     mac = "%12X" % uuid.getnode()
     mac = ':'.join([mac[i:i+2] for i in range(0, 12, 2)])
     return str(mac)
+
+
+def check_internet_access() -> bool:
+    """ Returns `True` when the network device is connected to the internet. """
+    try:
+
+        # Try to resolve Cloudflare's public DNS to check if DNS resolution works
+        socket.gethostbyname("www.cloudflare.com")
+
+        # Ping Cloudflare DNS to check for internet access
+        os_name = platform.system()
+
+        if os_name == 'Linux' or os_name == 'Darwin':  # macOS and Linux
+            result = subprocess.run(['ping', '-c', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if result.returncode == 0:
+                return True
+            else:
+                return False
+
+        if os_name == 'Windows':
+            result = subprocess.run(['ping', '-n', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if result.returncode == 0:
+                return True
+            else:
+                return False
+
+    except socket.gaierror:
+        return False
+
+
+def get_local_ip_address() -> str:
+    """ Connects to an external ip-address, which determines the appropriate
+    interface for the connection, and then returns the local ip-address used
+    in that connection.
+    """
+    if check_internet_access():
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(('1.1.1.1', 80))  # Cloudflare
+            ip_address = s.getsockname()[0]
+        return str(ip_address)
+    else:
+        raise NetworkConnectionError()
+
+
+def get_available_networks():
+    """ Retrieves the list of available wi-fi networks for a network device. """
+
+    if platform.system() == 'Linux':
+        try:
+            result = subprocess.run(
+                ['nmcli', '-t', '-f', 'SSID', 'device', 'wifi', 'list'],
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            networks = result.stdout.strip().split('\n')
+            return [net for net in networks if net]
+        except subprocess.CalledProcessError:
+            return []
+    else:
+        raise NetworkConnectionError()
+
+
+def connect_to_network(
+    ssid: str,
+    password: str
+):
+    """ Connects to a wi-fi network {ssid} with {password}.
+
+    Parameters
+    ----------
+    ssid: `str`
+        The name of the wi-fi network.
+    password: `str`
+        The password of the wi-fi network.
+    """
+    if platform.system() == 'Linux':
+        subprocess.run(
+            ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password],
+            check=True
+        )
+    else:
+        raise NetworkConnectionError()
+
+
+# Exception(s)
+class NetworkConnectionError(Exception):
+    pass

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -23,7 +23,7 @@ def get_interface_ip_address(interface: Literal['wlan0'] = 'wlan0') -> str:
     Parameters
     ----------
     interface: `str`
-        The network interface for the access point.
+        The network interface for the Wi-Fi connection.
     """
     address = netifaces.ifaddresses(interface)
     interface_address = address[netifaces.AF_INET][0]['addr']
@@ -43,7 +43,7 @@ def connected(interface: Literal['wlan0'] = 'wlan0') -> bool:
     Parameters
     ----------
     interface: `str`
-        The network interface for the access point.
+        The network interface for the Wi-Fi connection.
     """
     try:
 
@@ -96,7 +96,8 @@ def get_local_ip_address() -> str:
 @platform.requires('dietpi')
 async def connect(
     ssid: str,
-    password: Union[str, None]
+    password: Union[str, None],
+    interface: Literal['wlan0'] = 'wlan0'
 ):
     """ Connects to a Wi-Fi network {ssid} with {password}.
 
@@ -106,18 +107,20 @@ async def connect(
         The name of the Wi-Fi network.
     password: `str`
         The password of the Wi-Fi network.
+    interface: `str`
+        The network interface for Wi-Fi connections.
     """
     if not ssid:
         raise NetworkConnectionError('Invalid value. {ssid} cannot be empty.')
 
     if password:
         result = subprocess.run(
-            ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password],
+            ['nmcli', 'device', 'wifi', 'connect', ssid, 'password', password, 'ifname', interface],
             check=True
         )
     else:
         result = subprocess.run(
-            ['nmcli', 'device', 'wifi', 'connect', ssid],
+            ['nmcli', 'device', 'wifi', 'connect', ssid, 'ifname', interface],
             check=True
         )
 

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -18,7 +18,13 @@ def get_gateway_ip_address() -> str:
 
 
 def get_interface_ip_address(interface: Literal['wlan0'] = 'wlan0') -> str:
-    """ Returns the interface ip-address. """
+    """ Returns the interface ip-address.
+
+    Parameters
+    ----------
+    interface: `str`
+        The network interface for the access point.
+    """
     address = netifaces.ifaddresses(interface)
     interface_address = address[netifaces.AF_INET][0]['addr']
     return str(interface_address)
@@ -31,8 +37,14 @@ def get_local_mac_address() -> str:
     return str(mac)
 
 
-def connected() -> bool:
-    """ Returns `True` when the network device is connected to the internet. """
+def connected(interface: Literal['wlan0']) -> bool:
+    """ Returns `True` when the network device is connected to the internet.
+
+    Parameters
+    ----------
+    interface: `str`
+        The network interface for the access point.
+    """
     try:
 
         # Try to resolve Cloudflare's public DNS to check if DNS resolution works
@@ -40,14 +52,22 @@ def connected() -> bool:
 
         # Ping Cloudflare DNS to check for internet access
         if platform.NAME in ['dietpi', 'linux', 'darwin']:
-            result = subprocess.run(['ping', '-c', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            result = subprocess.run(
+                ['ping', '-c', '1', '-I', interface, '1.1.1.1'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
             if result.returncode == 0:
                 return True
             else:
                 return False
 
         elif platform.NAME == 'windows':
-            result = subprocess.run(['ping', '-n', '1', '1.1.1.1'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            result = subprocess.run(
+                ['ping', '-n', '1', '1.1.1.1'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
             if result.returncode == 0:
                 return True
             else:

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -78,14 +78,14 @@ async def connect(
     ssid: str,
     password: Union[str, None]
 ):
-    """ Connects to a wi-fi network {ssid} with {password}.
+    """ Connects to a Wi-Fi network {ssid} with {password}.
 
     Parameters
     ----------
     ssid: `str`
-        The name of the wi-fi network.
+        The name of the Wi-Fi network.
     password: `str`
-        The password of the wi-fi network.
+        The password of the Wi-Fi network.
     """
     if not ssid:
         raise NetworkConnectionError('Invalid value. {ssid} cannot be empty.')

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -1,6 +1,6 @@
 """ Network interfaces """
 
-from typing_extensions import Union
+from typing_extensions import Union, Literal
 import asyncio
 import socket
 import netifaces
@@ -10,11 +10,18 @@ import subprocess
 from audera import platform
 
 
-def get_gateway_ip_address():
+def get_gateway_ip_address() -> str:
     """ Returns the local gateway ip-address. """
     gateways = netifaces.gateways()
     gateway_address = gateways['default'][netifaces.AF_INET][0]
     return str(gateway_address)
+
+
+def get_interface_ip_address(interface: Literal['wlan0'] = 'wlan0') -> str:
+    """ Returns the interface ip-address. """
+    address = netifaces.ifaddresses(interface)
+    interface_address = address[netifaces.AF_INET][0]['addr']
+    return str(interface_address)
 
 
 def get_local_mac_address() -> str:

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -233,10 +233,7 @@ async def connect(
 
     # Delete the connection if it already exists
     if connection_exists(con_name=ssid):
-        delete_connection_result = subprocess.run(
-            ["nmcli", "connection", "delete", f"{ssid}"],
-            check=True
-        )
+        delete_connection_result = subprocess.run(["nmcli", "connection", "delete", f"{ssid}"])
 
         # Wait for the service
         if delete_connection_result.returncode == 0:
@@ -272,8 +269,7 @@ async def connect(
                 "wifi-sec.key-mgmt", f"{get_preferred_security_type(supported_security_types)}",
                 "wifi-sec.psk", f"{password}",
                 "connection.autoconnect", "yes"
-            ],
-            check=True
+            ]
         )
     else:
         add_connection_result = subprocess.run(
@@ -284,8 +280,7 @@ async def connect(
                 "con-name", f"{ssid}",
                 "ssid", f"{ssid}",
                 "connection.autoconnect", "yes"
-            ],
-            check=True
+            ]
         )
 
     # Wait for the service
@@ -310,10 +305,7 @@ async def connect(
                 )
             )
 
-    result = subprocess.run(
-        ["nmcli", "connection", "up", f"{ssid}"],
-        check=True
-    )
+    result = subprocess.run(["nmcli", "connection", "up", f"{ssid}"])
 
     if result.returncode == 0:
         pass

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -223,13 +223,13 @@ async def connect(
         The network interface for Wi-Fi connections.
     """
     if not ssid:
-        raise NetworkConnectionError('Invalid value. {ssid} cannot be empty.')
+        raise NetworkConnectionError('Invalid value. `Network` cannot be empty.')
 
     if supported_security_types and not password:
-        raise NetworkConnectionError('Invalid value. {password} cannot be empty for a secure network.')
+        raise NetworkConnectionError('Invalid value. `Password` cannot be empty for a secure network.')
 
     if password and not supported_security_types:
-        raise NetworkConnectionError('Invalid value. {supported_security_types} cannot be empty for a secure network.')
+        raise NetworkConnectionError(f'Invalid value. No available security protocols available for `{ssid}`.')
 
     # Delete the connection if it already exists
     if connection_exists(con_name=ssid):
@@ -251,7 +251,7 @@ async def connect(
 
             if connection_exists(con_name=ssid):
                 raise NetworkConnectionError(
-                    'Unable to delete Wi-Fi connection {%s} on interface {%s}.' % (
+                    'Unable to delete Wi-Fi connection `%s` on interface `%s`.' % (
                         ssid,
                         interface
                     )
@@ -299,7 +299,7 @@ async def connect(
 
         if not connection_exists(con_name=ssid):
             raise NetworkConnectionError(
-                'Unable to add Wi-Fi connection {%s} on interface {%s}.' % (
+                'Unable to add Wi-Fi connection `%s` on interface `%s`.' % (
                     ssid,
                     interface
                 )

--- a/audera/netifaces.py
+++ b/audera/netifaces.py
@@ -53,7 +53,7 @@ def connected(interface: Literal['wlan0'] = 'wlan0') -> bool:
         # Ping Cloudflare DNS to check for internet access
         if platform.NAME in ['dietpi', 'linux', 'darwin']:
             result = subprocess.run(
-                ['ping', '-c', '3', '-I', interface, '1.1.1.1'],
+                ['ping', '-c', '3', '-I', f"{interface}", '1.1.1.1'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE
             )
@@ -153,8 +153,8 @@ async def get_wifi_networks(interface: Literal['wlan0'] = 'wlan0') -> Dict[str, 
             "nmcli", "--terse",
             "--fields", "SSID,SECURITY",
             "device", "wifi", "list",
-            "ifname", interface,
-            "rescan", "yes",
+            "ifname", f"{interface}",
+            "--rescan", "yes",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -316,20 +316,7 @@ async def connect(
     )
 
     if result.returncode == 0:
-
-        # Check connection
-        time_out = 0
-
-        while time_out < 10:
-            await asyncio.sleep(1)
-
-            if connected(interface):
-                break
-
-            time_out += 1
-
-        if not connected(interface):
-            raise InternetConnectionError('Network `%s` has no internet.' % ssid)
+        pass
 
     elif result.returncode == 3:
         raise NetworkTimeoutError('Connection timed-out.')

--- a/audera/platform.py
+++ b/audera/platform.py
@@ -1,0 +1,55 @@
+""" Operating-system management """
+
+from typing import Callable, Literal
+import os
+import dotenv
+import platform
+
+# Load the dietpi os environment
+dotenv.load_dotenv('/boot/dietpi/.version')
+
+NAME = 'dietpi' if os.getenv('G_DIETPI_VERSION_CORE') else platform.system().strip().lower()
+VERSION = '.'.join(
+    os.getenv('G_DIETPI_VERSION_CORE', '0'),
+    os.getenv('G_DIETPI_VERSION_SUB', '0'),
+    os.getenv('G_DIETPI_VERSION_RC', '0')
+) if os.getenv('G_DIETPI_VERSION_CORE') else platform.version().strip().lower()
+
+
+# Decorator function(s)
+def requires(
+    platform_: Literal['any', 'dietpi', 'windows', 'linux', 'darwin'] = 'any'
+) -> Callable:
+    """ Raises an exception when the function is called on an unsupported platform.
+
+    Parameters
+    ----------
+    platform_: `Literal['any', 'dietpi', 'windows', 'linux', 'darwin'] = 'dietpi'`
+        The required platform. Default='dietpi'.
+    """
+
+    if platform_.strip().lower() not in ['any', 'dietpi', 'windows', 'linux', 'darwin']:
+        raise ValueError(
+            "Invalid platform {%s}. Platform must be either ['dietpi', 'windows', 'linux', 'darwin']." % (
+                platform_.strip().lower()
+            )
+        )
+
+    def decorator(func: Callable):
+        def wrapper(*args, **kwargs):
+
+            # Check the platform
+            if platform_.strip().lower() != 'any':
+                if NAME.strip().lower() != platform_.strip().lower():
+                    raise RuntimeError(
+                        "Invalid platform {%s}. %s() requires {%s}." % (
+                            NAME.strip().lower(),
+                            func.__name__,
+                            platform_.strip().lower()
+                        )
+                    )
+
+            return func(*args, **kwargs)
+        return wrapper
+
+    return decorator

--- a/audera/platform.py
+++ b/audera/platform.py
@@ -9,11 +9,11 @@ import platform
 dotenv.load_dotenv('/boot/dietpi/.version')
 
 NAME = 'dietpi' if os.getenv('G_DIETPI_VERSION_CORE') else platform.system().strip().lower()
-VERSION = '.'.join(
+VERSION = '.'.join([
     os.getenv('G_DIETPI_VERSION_CORE', '0'),
     os.getenv('G_DIETPI_VERSION_SUB', '0'),
     os.getenv('G_DIETPI_VERSION_RC', '0')
-) if os.getenv('G_DIETPI_VERSION_CORE') else platform.version().strip().lower()
+]) if os.getenv('G_DIETPI_VERSION_CORE') else platform.version().strip().lower()
 
 
 # Decorator function(s)

--- a/audera/player.py
+++ b/audera/player.py
@@ -62,12 +62,13 @@ class Service():
 
         # Initialize player
 
-        # The `get-or-create` method will either get the existing player or create a new player
-        #   from an identity. This ensures that when the ip-address of a player changes, a new
-        #   player is always created.
+        # The `update` method will either get the existing player, create a new player or
+        #   update an existing player from the identity.
 
-        self.player: audera.struct.player.Player = audera.struct.player.Player.from_config(
-            audera.dal.players.get_or_create(self.identity)
+        self.player: audera.struct.player.Player = audera.dal.players.update(
+            audera.struct.player.Player.from_config(
+                audera.dal.players.get_or_create(self.identity)
+            )
         )
 
         # Initialize playback session

--- a/audera/player.py
+++ b/audera/player.py
@@ -3,7 +3,6 @@
 import asyncio
 import time
 import struct
-import platform
 from zeroconf import Zeroconf
 
 import audera
@@ -138,8 +137,7 @@ class Service():
         while True:
 
             # Check the operating-system
-            operating_system = platform.system()
-            if operating_system not in ['Linux', 'Darwin']:
+            if audera.platform.NAME not in ['dietpi', 'linux', 'darwin']:
 
                 # Logging
                 self.logger.warning(

--- a/audera/player.py
+++ b/audera/player.py
@@ -44,9 +44,9 @@ class Service():
         # The `update` method will either get the existing identity, create a new identity or
         #   update the existing identity with new network interface settings. Unlike other
         #   `audera` structure objects, where equality is based on every object attribute,
-        #   identities are only considered to be the same if they share the same uuid and
-        #   mac address. Finally, the name of an identity is immutable, when an identity is updated
-        #   the same name is always retained.
+        #   identities are only considered to be the same if they share the same mac address and
+        #   ip-address. Finally, the name and uuid of an identity are immutable, when an identity is updated
+        #   the same name and uuid are always retained.
 
         self.mac_address = audera.netifaces.get_local_mac_address()
         self.player_ip_address = audera.netifaces.get_local_ip_address()
@@ -64,11 +64,7 @@ class Service():
         # The `update` method will either get the existing player, create a new player or
         #   update an existing player from the identity.
 
-        self.player: audera.struct.player.Player = audera.dal.players.update(
-            audera.struct.player.Player.from_config(
-                audera.dal.players.get_or_create(self.identity)
-            )
-        )
+        self.player: audera.struct.player.Player = audera.dal.players.update_identity(self.identity)
 
         # Initialize playback session
 

--- a/audera/streamer.py
+++ b/audera/streamer.py
@@ -76,7 +76,6 @@ class Service():
         self.stream_session: audera.sessions.Stream = audera.sessions.Stream(
             session=audera.dal.sessions.update(
                 audera.struct.session.Session(
-                    name=self.identity.name,
                     uuid=self.identity.uuid,
                     mac_address=self.identity.mac_address,
                     address=self.identity.address,

--- a/audera/struct/identity.py
+++ b/audera/struct/identity.py
@@ -128,9 +128,6 @@ class Identity():
             An instance of an `audera.struct.player.Identity` object.
         """
         if isinstance(compare, Identity):
-            return (
-                self.address == compare.address
-                and self.mac_address == compare.mac_address
-            )
+            return (self.mac_address == compare.mac_address)
 
         return False

--- a/audera/struct/identity.py
+++ b/audera/struct/identity.py
@@ -129,7 +129,7 @@ class Identity():
         """
         if isinstance(compare, Identity):
             return (
-                self.uuid == compare.uuid
+                self.address == compare.address
                 and self.mac_address == compare.mac_address
             )
 

--- a/audera/struct/identity.py
+++ b/audera/struct/identity.py
@@ -55,6 +55,13 @@ class Identity():
     mac_address: str
     address: str
 
+    @property
+    def short_uuid(self) -> str:
+        """ Returns the short unique universal identifier of the `audera.struct.identity.Identity`
+        object.
+        """
+        return self.uuid.split('-')[0]
+
     def from_dict(dict_object: dict) -> Identity:
         """ Returns an `audera.struct.player.Identity` object from a `dict`.
 

--- a/audera/struct/identity.py
+++ b/audera/struct/identity.py
@@ -128,6 +128,9 @@ class Identity():
             An instance of an `audera.struct.player.Identity` object.
         """
         if isinstance(compare, Identity):
-            return (self.mac_address == compare.mac_address)
+            return (
+                self.mac_address == compare.mac_address
+                and self.address == compare.address
+            )
 
         return False

--- a/audera/struct/session.py
+++ b/audera/struct/session.py
@@ -31,10 +31,10 @@ class Session():
         A float value from 0 to 100 that sets the loudness of playback. A value of
             0 is muted.
     """
-    name: str
     uuid: str
     mac_address: str
     address: str
+    name: str = field(default='')
     group: str = field(default='')
     players: List[str] = field(default_factory=list)
     provider: Literal['audera'] = field(default='audera')

--- a/audera/ui/__init__.py
+++ b/audera/ui/__init__.py
@@ -1,0 +1,5 @@
+""" User-interfaces """
+
+from audera.ui import player
+
+__all__ = ['player']

--- a/audera/ui/player/__init__.py
+++ b/audera/ui/player/__init__.py
@@ -1,0 +1,5 @@
+""" Remote audio output player user-interface """
+
+from audera.ui.player import setup
+
+__all__ = ['setup']

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -46,7 +46,7 @@ class Page():
         # Initialize access-point
         self.ap = audera.ap.AccessPoint(
             name=audera.NAME,
-            url='https://player-setup.audera.local',
+            url='http://player-setup.audera.com',
             interface='wlan0',
             identity=identity
         )

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -1,0 +1,402 @@
+""" Remote audio output player setup """
+
+from typing_extensions import Union
+from nicegui import app, ui
+
+import audera
+
+
+class Page():
+    """ A `class` that represents a player setup page.
+
+    Parameters
+    ----------
+    identity: `audera.struct.identity.Identity`
+        An instance of an `audera.struct.identity.Identity` object.
+    """
+
+    def __init__(self, identity: audera.struct.identity.Identity):
+        """ Initializes an instance of the `audera` player setup page.
+
+        Parameters
+        ----------
+        identity: `audera.struct.identity.Identity`
+            An instance of an `audera.struct.identity.Identity` object.
+        """
+
+        # Initialize player
+
+        # The `update` method will either get the existing player, create a new player or
+        #   update an existing player from the identity.
+
+        self.player: audera.struct.player.Player = audera.dal.players.update(
+            audera.struct.player.Player.from_config(
+                audera.dal.players.get_or_create(identity)
+            )
+        )
+
+        # Initialize connected network ssid
+        self.connected_profile: Union[str, None] = None
+
+        # Initialize available networks
+        self.network_refreshing: bool = False
+
+    @property
+    def name(self):
+        return str(self.player.name)
+
+    def update_player_name_callback(self, name: Union[str, None]):
+        """ Updates the name of the remote audio output player.
+
+        Parameters
+        ----------
+        name: `Union[str, None]`
+            The new name of the remote audio output player.
+        """
+        if name and name != self.player.name:
+            self.player = audera.dal.players.update_player_name(self.player, str(name))
+            ui.notify('Player name updated.', position='top-right', type='positive')
+
+    async def connect_callback(self, ssid: str, password: str):
+        """ Connects to an available Wi-Fi network and checks for a valid internet connection.
+
+        Parameters
+        ----------
+        ssid: `str`
+            The name of the wi-fi network.
+        password: `str`
+            The password of the wi-fi network.
+        """
+
+        # Start
+        self.network_refreshing = True
+
+        if not ssid:
+            ui.notify(
+                'Enter a network.',
+                position='top-right',
+                type='negative'
+            )
+
+        else:
+            try:
+                await audera.netifaces.connect(ssid, password)
+                self.connected_profile = ssid
+                ui.notify(
+                    'Network `%s` connected successfully.' % ssid,
+                    position='top-right',
+                    type='positive'
+                )
+
+            except OSError:
+                ui.notify(
+                    'Network setup is unavailable.',
+                    position='top-right',
+                    type='negative'
+                )
+
+            except audera.netifaces.NetworkConnectionError:
+                ui.notify(
+                    'Unable to connect to `%s`.' % ssid,
+                    position='top-right',
+                    type='negative'
+                )
+
+            except audera.netifaces.InternetConnectionError:
+                ui.notify(
+                    '`%s` has no internet.' % ssid,
+                    position='top-right',
+                    type='negative'
+                )
+
+            except audera.netifaces.NetworkTimeoutError:
+                ui.notify(
+                    '`%s` is inaccessible.' % ssid,
+                    position='top-right',
+                    type='negative'
+                )
+
+            except audera.netifaces.NetworkNotFoundError:
+                ui.notify(
+                    '`%s` is unavailable.' % ssid,
+                    position='top-right',
+                    type='negative'
+                )
+
+        # Stop
+        self.network_refreshing = False
+
+    def load(self):
+        """ Returns the page content. """
+        ui.page('/', title='%s \u2014 👋 Welcome' % audera.NAME.lower())(self.welcome)
+        ui.page('/discover', title='%s \u2014 Discover' % audera.NAME.lower())(self.discover)
+        ui.page('/setup', title='%s \u2014 Setup' % audera.NAME.lower())(self.setup)
+        ui.page('/connect', title='%s \u2014 Connect' % audera.NAME.lower())(self.connect)
+        ui.page('/finish', title='%s \u2014 Finish' % audera.NAME.lower())(self.finish)
+
+    def welcome(self):
+        """ Returns the welcome page content. """
+
+        with ui.row().classes("flex w-full"):
+            ui.label('%s \u2014 👋 Welcome' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.icon("circle", size=".7rem", color='primary').classes("self-center ml-auto")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center mr-3")
+
+        # Welcome
+        with ui.card().classes("mx-auto flex w-full"):
+            ui.markdown("Welcome to **audera**").classes("text-3xl")
+            ui.markdown(audera.DESCRIPTION.replace('`', '**'))
+            ui.markdown('Click **Continue** to connect to your player.')
+
+            with ui.row().classes("flex w-full"):
+                ui.button(
+                    'Continue',
+                    on_click=lambda: ui.navigate.to('/discover')
+                ).props('rounded').classes("ml-auto normal-case")
+
+    def discover(self):
+        """ Returns the discover page content. """
+
+        with ui.row().classes("flex w-full"):
+            ui.label('%s \u2014 Discover' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center ml-auto")
+            ui.icon("circle", size=".7rem", color='primary').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center mr-3")
+
+        # Discover
+        with ui.card().classes("flex mx-auto w-full"):
+            ui.markdown(
+                "✨ Your **audera** remote audio output player connected successfully"
+            ).classes("text-3xl")
+
+            with ui.card().classes("mx-auto flex w-full"):
+                with ui.row().classes("flex items-center justify-center"):
+                    ui.icon("sym_r_speaker", size='lg').classes("text-lg")
+                    ui.chip(
+                        icon='sym_r_cast_connected',
+                        color='gray-200'
+                    ).bind_text_from(self, 'name').classes("font-md")
+
+            with ui.row().classes("flex w-full"):
+                ui.button('Back', on_click=lambda: ui.navigate.to('/')).props('flat rounded').classes("normal-case")
+                ui.button('Setup', on_click=lambda: ui.navigate.to('/setup')).props('rounded').classes("ml-auto normal-case")
+
+    def setup(self):
+        """ Returns the setup page content. """
+
+        with ui.row().classes("flex w-full"):
+            ui.label('%s \u2014 Setup' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center ml-auto")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='primary').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center mr-3")
+
+        # Setup
+        with ui.card().classes("mx-auto flex w-full"):
+            ui.markdown("Where is your player?").classes("text-3xl")
+            ui.markdown("Naming your **audera** player will help organize your players for playback sessions and player groups.")
+            ui.input(
+                placeholder='Name',
+                value=str(self.player.name),
+                autocomplete=[
+                    "Living Room",
+                    "Kitchen",
+                    "Bedroom",
+                    "Bathroom",
+                    "Dining Room",
+                    "Office",
+                    "Laundry Room",
+                    "Hallway",
+                    "Garage",
+                    "Guest Room",
+                    "Basement",
+                    "Utility Room"
+                ],
+                validation={
+                    "The player name cannot be empty.": lambda value: value is not None
+                }
+            ).props('clearable rounded-md outlined dense').classes('w-full').on(
+                'blur',
+                lambda event: self.update_player_name_callback(event.sender.value)
+            ).on(
+                'keyboard.enter',
+                lambda event: self.update_player_name_callback(event.sender.value)
+            ).on(
+                'keyboard.down',
+                lambda event: self.update_player_name_callback(event.sender.value)
+            )
+
+            with ui.row().classes("flex w-full"):
+                ui.button(
+                    'Back',
+                    on_click=lambda: ui.navigate.to('/discover')
+                ).props('flat rounded').classes("normal-case")
+                ui.button(
+                    'Continue',
+                    on_click=lambda: ui.navigate.to('/connect')
+                ).props('rounded').classes("ml-auto normal-case")
+
+    def connect(self):
+        """ Returns the connect page content. """
+
+        with ui.row().classes("flex w-full"):
+            ui.label('%s \u2014 Connect' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center ml-auto")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='primary').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center mr-3")
+
+        # Connect
+        with ui.card().classes("mx-auto flex w-full"):
+            ui.markdown(
+                "Connect to Wi-Fi"
+            ).classes("text-3xl")
+            ui.markdown(
+                "Input the credentials for the Wi-Fi network you would like to use with your **audera** player."
+            )
+
+            self.password_selector = ui.switch(
+                '🔒',
+                value=True
+            ).classes("ml-auto")
+
+            with ui.card().classes("mx-auto flex w-full"):
+
+                self.network_input = ui.input(
+                    placeholder="Network",
+                ).props('clearable rounded-md outlined dense').classes("w-full")
+
+                self.password_input = ui.input(
+                    placeholder="Password",
+                    password=True,
+                    password_toggle_button=True
+                ).bind_visibility_from(
+                    self,
+                    'password_selector',
+                    backward=lambda password_selector: password_selector.value
+                ).props('clearable rounded-md outlined dense').classes("w-full")
+
+                with ui.row().classes("flex w-full"):
+                    ui.button(
+                        "Connect",
+                        on_click=lambda: self.connect_callback(
+                            self.network_input.value,
+                            self.password_input.value
+                        )
+                    ).props('rounded').classes("normal-case")
+                    ui.spinner(size='md').bind_visibility_from(
+                        self,
+                        'network_refreshing'
+                    )
+
+            with ui.row().classes("flex w-full"):
+                ui.button('Back', on_click=lambda: ui.navigate.to('/setup')).props('flat rounded').classes("normal-case")
+                ui.button(
+                    "Continue",
+                    on_click=lambda: ui.navigate.to('/finish')
+                ).bind_enabled_from(
+                    self,
+                    'connected_profile',
+                    backward=lambda enabled: True if enabled else False
+                ).props('rounded').classes("ml-auto normal-case")
+
+    def finish(self):
+        """ Returns the finish page content. """
+
+        with ui.row().classes("flex w-full"):
+            ui.label('%s \u2014 Finish' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center ml-auto")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
+            ui.icon("circle", size=".7rem", color='primary').classes("self-center mr-3")
+
+        # Finish
+        with ui.card().classes("mx-auto flex w-full"):
+            ui.markdown("🎉 Your player was setup successfully").classes("text-3xl")
+            ui.markdown(
+                """
+                Click **Finish** below to start listening.
+                """
+            )
+            ui.markdown(
+                """
+                Once your player restarts, connect to your **audera** streamer to start a playback session, or,
+                cast directly to your player through any AirPlay enabled device.
+                """
+            )
+            ui.markdown(
+                """
+                To learn more about the **audera** ecosystem, check out the [Github](%s).
+                """ % (audera.HOME)
+            )
+
+            with ui.row().classes("flex w-full"):
+                ui.button(
+                    'Back',
+                    on_click=lambda: ui.navigate.to('/connect')
+                ).props('flat rounded').classes("normal-case")
+                ui.button("Finish", on_click=app.shutdown).props('rounded').classes("ml-auto normal-case")
+
+
+if __name__ in ["__main__", "__mp_main__"]:
+
+    # Initialize identity
+
+    # The `update` method will either get the existing identity, create a new identity or
+    #   update the existing identity with new network interface settings. Unlike other
+    #   `audera` structure objects, where equality is based on every object attribute,
+    #   identities are only considered to be the same if they share the same uuid and
+    #   mac address. Finally, the name of an identity is immutable, when an identity is updated
+    #   the same name is always retained.
+
+    mac_address = audera.netifaces.get_local_mac_address()
+    try:
+        player_ip_address = audera.netifaces.get_local_ip_address()
+    except audera.netifaces.NetworkConnectionError:
+        player_ip_address = ''
+
+    identity: audera.struct.identity.Identity = audera.dal.identities.update(
+        audera.struct.identity.Identity(
+            name=audera.struct.identity.generate_cool_name(),
+            uuid=audera.struct.identity.generate_uuid_from_mac_address(mac_address),
+            mac_address=mac_address,
+            address=player_ip_address
+        )
+    )
+
+    if not audera.netifaces.connected():
+
+        # Create an access point based on the player identity
+        ap = audera.ap.AccessPoint(
+            name=audera.NAME,
+            identity=identity
+        )
+
+        try:
+            ap.start()
+        except audera.ap.AccessPointError:
+            raise audera.ap.AccessPointError('Access-point setup is only available on Linux.')
+
+    # Initialize the ui
+    page = Page(identity)
+
+    # Load the page content
+    page.load()
+
+    # Run the app
+    try:
+        ui.run(
+            title=audera.NAME.strip().lower(),
+            show=False,
+            reload=False
+        )
+    except KeyboardInterrupt:
+        app.shutdown()

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -406,7 +406,7 @@ def run():
     # Run the app
     try:
         ui.run(
-            host=audera.netifaces.get_interface_ip_address('wlan0'),
+            host='127.0.0.1',
             title=audera.NAME.strip().lower(),
             show=False,
             reload=False

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -317,7 +317,7 @@ class Page():
             ui.button(
                 "Refresh",
                 on_click=self.refresh_callback
-            ).classes("ml-auto")
+            ).props('rounded').classes("ml-auto normal-case")
 
             with ui.card().classes("mx-auto flex w-full"):
                 self.network_selector = ui.select(
@@ -345,7 +345,7 @@ class Page():
                         self,
                         'network_selector',
                         backward=lambda network_selector: network_selector.value
-                    ).props('rounded').classes("normal-case")
+                    ).props('rounded').classes("ml-auto normal-case")
                     ui.spinner(size='md').bind_visibility_from(
                         self,
                         'network_refreshing'

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -3,6 +3,7 @@
 from typing_extensions import Union
 import os
 import time
+import asyncio
 from nicegui import app, ui
 
 import audera
@@ -94,9 +95,17 @@ class Page():
             )
 
         else:
+
+            # Temporarily bring down the access point
+            self.ap.down()
+            await asyncio.sleep(3)
+
             try:
+
+                # Connect
                 await audera.netifaces.connect(ssid, password)
                 self.connected_profile = ssid
+
                 ui.notify(
                     'Network `%s` connected successfully.' % ssid,
                     position='top-right',
@@ -137,6 +146,9 @@ class Page():
                     position='top-right',
                     type='negative'
                 )
+
+            # Bring back up the access point
+            self.ap.up()
 
         # Stop
         self.network_refreshing = False

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -345,7 +345,7 @@ class Page():
                         self,
                         'network_selector',
                         backward=lambda network_selector: network_selector.value
-                    ).props('rounded').classes("ml-auto normal-case")
+                    ).props('rounded').classes("normal-case")
                     ui.spinner(size='md').bind_visibility_from(
                         self,
                         'network_refreshing'

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -143,7 +143,7 @@ class Page():
 
             except audera.netifaces.NetworkConnectionError as e:
                 ui.notify(
-                    'Unable to connect to `%s`. %s' % (ssid, str(e)),
+                    str(e),
                     position='top-right',
                     type='negative'
                 )
@@ -446,7 +446,8 @@ def run():
             port=80,
             title=audera.NAME.strip().lower(),
             show=False,
-            reload=False
+            reload=False,
+            reconnect_timeout=60
         )
     except KeyboardInterrupt:
         app.shutdown()

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -195,11 +195,11 @@ class Page():
         with ui.card().classes("mx-auto flex w-full"):
             ui.markdown("Welcome to **audera** 👋").classes("text-3xl")
             ui.markdown(audera.DESCRIPTION.replace('`', '**'))
-            ui.markdown('Click **Continue** to connect to your player.')
+            ui.markdown('Click **Start** to connect to your player.')
 
             with ui.row().classes("flex w-full"):
                 ui.button(
-                    'Continue',
+                    'Start',
                     on_click=lambda: ui.navigate.to('/discover')
                 ).props('rounded').classes("ml-auto normal-case")
 
@@ -213,9 +213,6 @@ class Page():
             ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
             ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
             ui.icon("circle", size=".7rem", color='gray-100').classes("self-center mr-3")
-
-        # Pre-load the list of available Wi-Fi networks
-        self.wifi_networks = await audera.netifaces.get_wifi_networks(interface='wlan0')
 
         # Discover
         with ui.card().classes("flex mx-auto w-full"):
@@ -234,6 +231,9 @@ class Page():
             with ui.row().classes("flex w-full"):
                 ui.button('Back', on_click=lambda: ui.navigate.to('/')).props('flat rounded').classes("normal-case")
                 ui.button('Setup', on_click=lambda: ui.navigate.to('/setup')).props('rounded').classes("ml-auto normal-case")
+
+        # Pre-load the list of available Wi-Fi networks
+        self.wifi_networks = await audera.netifaces.get_wifi_networks(interface='wlan0')
 
     def setup(self):
         """ Returns the setup page content. """

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -31,11 +31,7 @@ class Page():
         # The `update` method will either get the existing player, create a new player or
         #   update an existing player from the identity.
 
-        self.player: audera.struct.player.Player = audera.dal.players.update(
-            audera.struct.player.Player.from_config(
-                audera.dal.players.get_or_create(identity)
-            )
-        )
+        self.player: audera.struct.player.Player = audera.dal.players.update_identity(identity)
 
         # Initialize connected network ssid
         self.connected_profile: Union[str, None] = None
@@ -418,9 +414,9 @@ def run():
     # The `update` method will either get the existing identity, create a new identity or
     #   update the existing identity with new network interface settings. Unlike other
     #   `audera` structure objects, where equality is based on every object attribute,
-    #   identities are only considered to be the same if they share the same uuid and
-    #   mac address. Finally, the name of an identity is immutable, when an identity is updated
-    #   the same name is always retained.
+    #   identities are only considered to be the same if they share the same mac address and
+    #   ip-address. Finally, the name and uuid of an identity are immutable, when an identity is updated
+    #   the same name and uuid are always retained.
 
     mac_address = audera.netifaces.get_local_mac_address()
     try:

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -17,6 +17,7 @@ class Page():
         An instance of an `audera.struct.identity.Identity` object.
     """
 
+    @audera.platform.requires('dietpi')
     def __init__(self, identity: audera.struct.identity.Identity):
         """ Initializes an instance of the player setup app.
 
@@ -265,7 +266,8 @@ class Page():
                     "Garage",
                     "Guest Room",
                     "Basement",
-                    "Utility Room"
+                    "Utility Room",
+                    "She shed"
                 ],
                 validation={
                     "The player name cannot be empty.": lambda value: value is not None

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -63,9 +63,9 @@ class Page():
         Parameters
         ----------
         ssid: `str`
-            The name of the wi-fi network.
+            The name of the Wi-Fi network.
         password: `str`
-            The password of the wi-fi network.
+            The password of the Wi-Fi network.
         """
 
         # Start
@@ -372,13 +372,15 @@ if __name__ in ["__main__", "__mp_main__"]:
         )
     )
 
-    if not audera.netifaces.connected():
+    # Create an access point based on the player identity
+    ap = audera.ap.AccessPoint(
+        name=audera.NAME,
+        url='https://player-setup.audera.local',
+        interface='wlan0',
+        identity=identity
+    )
 
-        # Create an access point based on the player identity
-        ap = audera.ap.AccessPoint(
-            name=audera.NAME,
-            identity=identity
-        )
+    if not audera.netifaces.connected():
 
         try:
             ap.start()
@@ -400,3 +402,7 @@ if __name__ in ["__main__", "__mp_main__"]:
         )
     except KeyboardInterrupt:
         app.shutdown()
+
+    # Clean up the access point if it was created
+    if ap is not None:
+        ap.stop()

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -88,7 +88,7 @@ class Page():
                     type='positive'
                 )
 
-            except OSError:
+            except RuntimeError:
                 ui.notify(
                     'Network setup is unavailable.',
                     position='top-right',
@@ -128,7 +128,7 @@ class Page():
 
     def load(self):
         """ Returns the page content. """
-        ui.page('/', title='%s \u2014 👋 Welcome' % audera.NAME.lower())(self.welcome)
+        ui.page('/', title='%s \u2014 Welcome' % audera.NAME.lower())(self.welcome)
         ui.page('/discover', title='%s \u2014 Discover' % audera.NAME.lower())(self.discover)
         ui.page('/setup', title='%s \u2014 Setup' % audera.NAME.lower())(self.setup)
         ui.page('/connect', title='%s \u2014 Connect' % audera.NAME.lower())(self.connect)
@@ -138,7 +138,7 @@ class Page():
         """ Returns the welcome page content. """
 
         with ui.row().classes("flex w-full"):
-            ui.label('%s \u2014 👋 Welcome' % audera.NAME.lower()).classes('self-center text-sm ml-3')
+            ui.label('%s \u2014 Welcome' % audera.NAME.lower()).classes('self-center text-sm ml-3')
             ui.icon("circle", size=".7rem", color='primary').classes("self-center ml-auto")
             ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
             ui.icon("circle", size=".7rem", color='gray-100').classes("self-center")
@@ -147,7 +147,7 @@ class Page():
 
         # Welcome
         with ui.card().classes("mx-auto flex w-full"):
-            ui.markdown("Welcome to **audera**").classes("text-3xl")
+            ui.markdown("Welcome to **audera** 👋").classes("text-3xl")
             ui.markdown(audera.DESCRIPTION.replace('`', '**'))
             ui.markdown('Click **Continue** to connect to your player.')
 
@@ -382,8 +382,8 @@ if __name__ in ["__main__", "__mp_main__"]:
 
         try:
             ap.start()
-        except audera.ap.AccessPointError:
-            raise audera.ap.AccessPointError('Access-point setup is only available on Linux.')
+        except RuntimeError:
+            raise audera.ap.AccessPointError('Access-point setup is only available on dietpi-os.')
 
     # Initialize the ui
     page = Page(identity)

--- a/audera/ui/player/setup.py
+++ b/audera/ui/player/setup.py
@@ -406,7 +406,8 @@ def run():
     # Run the app
     try:
         ui.run(
-            host='127.0.0.1',
+            host='0.0.0.0',  # Any interface
+            port=80,
             title=audera.NAME.strip().lower(),
             show=False,
             reload=False

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -49,8 +49,8 @@ echo "    Script source {https://raw.githubusercontent.com/thomaseleff/audera/re
 # Ensure the script is running as root
 echo
 if [[ $EUID -ne 0 ]]; then
-   echo -e "${RED}*** CRITICAL: The setup-script must be run as {sudo}.${RESET}" 
-   exit 1
+    echo -e "${RED}*** CRITICAL: The setup-script must be run as {sudo}.${RESET}" 
+    exit 1
 fi
 
 # Install build packages
@@ -73,50 +73,14 @@ apt-get install -y \
     cmake
 echo -e "[  ${GREEN}OK${RESET}  ] Packages installed successfully"
 
-# Purge ifupdown
-
-# ifupdown will conflict with Network-Manager if
-#   both are installed. Comment out all configuration
-#   from `/etc/network/interfaces`.
-
-echo
-echo ">>> Purging ifupdown"
-
-if sudo systemctl is-active --quiet ifupdown; then
-    sudo systemctl stop ifupdown
-    sudo systemctl disable ifupdown
-fi
-
-sudo apt-get purge -y ifupdown
-sudo sed -i '/^[[:space:]]*[^#[:space:]]/s/^/# /' /etc/network/interfaces
-echo -e "[  ${GREEN}OK${RESET}  ] ifupdown purged successfully"
-
-# Setup network-manager
-
-# Network-manager should manage all network devices,
-#   even those configured within `/etc/network/interfaces`.
-
-echo
-echo ">>> Setting up network-manager"
-sudo sed -i '/^\[ifupdown\]/,/^\[/s/managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
-sudo systemctl enable NetworkManager
-sudo systemctl restart NetworkManager
-echo -e "[  ${GREEN}OK${RESET}  ] Network-manager setup successfully"
-
-# Setup dnsmasq
-echo
-echo ">>> Setting up dnsmasq"
-sudo systemctl disable dnsmasq
-echo -e "[  ${GREEN}OK${RESET}  ] dnsmasq setup successfully"
-
 # Clone the git repository
 echo
 if [ ! -d "$WORKSPACE" ]; then
-  echo ">>> Cloning the Git repository"
-  git clone -b "$GIT_BRANCH" "$GIT_REPO_URL" "$WORKSPACE"
+    echo ">>> Cloning the Git repository"
+    git clone -b "$GIT_BRANCH" "$GIT_REPO_URL" "$WORKSPACE"
 else
-  echo ">>> Pulling the Git repository"
-  cd "$WORKSPACE" && git pull origin "$GIT_BRANCH"
+    echo ">>> Pulling the Git repository"
+    cd "$WORKSPACE" && git pull origin "$GIT_BRANCH"
 fi
 echo -e "[  ${GREEN}OK${RESET}  ] Git repository created successfully"
 
@@ -130,25 +94,25 @@ echo -e "[  ${GREEN}OK${RESET}  ] shairport-sync configured successfully"
 # Create the Python virtual environment
 echo
 if [ ! -d "$WORKSPACE/.venv" ]; then
-  echo ">>> Creating the Python virtual env {$WORKSPACE/.venv}"
-  python3 -m venv "$WORKSPACE/.venv"
-  echo ">>> Activating the Python virtual env"
-  source "$WORKSPACE/.venv/bin/activate"
+    echo ">>> Creating the Python virtual env {$WORKSPACE/.venv}"
+    python3 -m venv "$WORKSPACE/.venv"
+    echo ">>> Activating the Python virtual env"
+    source "$WORKSPACE/.venv/bin/activate"
 else
-  echo ">>> Activating the Python virtual env"
-  source "$WORKSPACE/.venv/bin/activate"
+    echo ">>> Activating the Python virtual env"
+    source "$WORKSPACE/.venv/bin/activate"
 fi
 echo -e "[  ${GREEN}OK${RESET}  ] Python virtual env created successfully"
 
 # Install Python requirements
 echo
 if [ -f "$WORKSPACE/requirements.txt" ]; then
-  echo ">>> Installing the Python requirements"
-  python3 -m pip install --upgrade pip
-  pip3 install -e "$WORKSPACE" --no-deps
+    echo ">>> Installing the Python requirements"
+    python3 -m pip install --upgrade pip
+    pip3 install -e "$WORKSPACE" --no-deps
 else
-  echo -e "${RED} ** ERROR: Failed to build & install audera.${RESET}"
-  exit 1
+    echo -e "${RED} ** ERROR: Failed to build & install audera.${RESET}"
+    exit 1
 fi
 echo -e "[  ${GREEN}OK${RESET}  ] Python requirements installed successfully"
 
@@ -159,6 +123,43 @@ echo ">>> Ensuring wifi availability without hdmi-output"
 G_CONFIG_INJECT 'hdmi_force_hotplug=' 'hdmi_force_hotplug=1' /boot/config.txt
 G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=2' /boot/config.txt
 echo -e "[  ${GREEN}OK${RESET}  ] os configured successfully"
+
+# Purge ifupdown
+
+# ifupdown will conflict with Network-Manager if
+#   both are installed. Comment out all configuration
+#   from `/etc/network/interfaces`.
+
+echo
+echo ">>> Purging ifupdown"
+
+if systemctl is-active --quiet ifupdown; then
+    systemctl stop ifupdown
+    systemctl disable ifupdown
+fi
+
+apt-get purge -y ifupdown
+sed -i '/^[[:space:]]*[^#[:space:]]/s/^/# /' /etc/network/interfaces
+echo -e "[  ${GREEN}OK${RESET}  ] ifupdown purged successfully"
+
+# Setup network-manager
+
+# Network-manager should manage all network devices,
+#   even those configured within `/etc/network/interfaces`.
+
+echo
+echo ">>> Setting up network-manager"
+sed -i '/^\[ifupdown\]/,/^\[/s/managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
+systemctl enable NetworkManager
+systemctl restart NetworkManager
+nmcli networking on
+echo -e "[  ${GREEN}OK${RESET}  ] Network-manager setup successfully"
+
+# Setup dnsmasq
+echo
+echo ">>> Setting up dnsmasq"
+systemctl disable dnsmasq
+echo -e "[  ${GREEN}OK${RESET}  ] dnsmasq setup successfully"
 
 # Configure alsa
 echo
@@ -171,13 +172,13 @@ echo -e "[  ${GREEN}OK${RESET}  ] alsa configured successfully"
 # Set up the autostart script
 echo
 if [ ! -d "$AUTOSTART_DIRECTORY" ]; then
-  echo ">>> Creating the custom autostart directory"
-  mkdir "$AUTOSTART_DIRECTORY"
-  echo ">>> Creating the custom autostart script"
-  cp "$REPO_AUTOSTART_SCRIPT" "$AUTOSTART_SCRIPT"
-  chmod +x "$AUTOSTART_SCRIPT"
+    echo ">>> Creating the custom autostart directory"
+    mkdir "$AUTOSTART_DIRECTORY"
+    echo ">>> Creating the custom autostart script"
+    cp "$REPO_AUTOSTART_SCRIPT" "$AUTOSTART_SCRIPT"
+    chmod +x "$AUTOSTART_SCRIPT"
 else
-  echo -e "${YELLOW}  * WARNING: Autostart script already exists.${RESET}"
+    echo -e "${YELLOW}  * WARNING: Autostart script already exists.${RESET}"
 fi
 echo -e "[  ${GREEN}OK${RESET}  ] Custom autostart script created successfully"
 

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -30,8 +30,10 @@ AUTOSTART_SCRIPT="$AUTOSTART_DIRECTORY/custom.sh"
 REPO_AUTOSTART_SCRIPT="$WORKSPACE/os/dietpi/player/automation/autostart.sh"
 
 # Start console logging
-#   The logo must be wrapped in single quotes ' ' to avoid escaping characters
-#       due to the nature of having double backslashes, like '\\' in the logo
+
+# The logo must be wrapped in single quotes ' ' to avoid escaping characters
+#   due to the nature of having double backslashes, like '\\' in the logo
+
 echo ' ________  ___  ___  ________  _______  ________  ________      '
 echo '|\   __  \|\  \|\  \|\   ___ \|\   ___\|\   __  \|\   __  \     '
 echo '\ \  \|\  \ \  \\\  \ \  \_|\ \ \  \__|\ \  \|\  \ \  \|\  \    '

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -109,7 +109,7 @@ echo
 if [ -f "$WORKSPACE/requirements.txt" ]; then
     echo ">>> Installing the Python requirements"
     python3 -m pip install --upgrade pip
-    pip3 install -e "$WORKSPACE" --no-deps
+    pip3 install -e "$WORKSPACE"
 else
     echo -e "${RED} ** ERROR: Failed to build & install audera.${RESET}"
     exit 1

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -48,7 +48,7 @@ fi
 echo ">>> Installing build packages"
 apt-get update && \
 apt-get install -y \
-    nmcli \
+    network-manager \
     alsa-utils \
     ffmpeg \
     shairport-sync \

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -65,6 +65,11 @@ apt-get install -y \
     cmake
 echo -e "[  ${GREEN}OK${RESET}  ] Packages installed successfully"
 
+# Disabling services
+echo ">>> Disabling Wi-Fi access-point services"
+sudo systemctl disable hostapd dnsmasq
+echo -e "[  ${GREEN}OK${RESET}  ] Services disabled successfully"
+
 # Clone the git repository
 echo
 if [ ! -d "$WORKSPACE" ]; then

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -51,6 +51,8 @@ apt-get install -y \
     alsa-utils \
     ffmpeg \
     shairport-sync \
+    hostapd \
+    dnsmasq \
     git \
     python3.11 \
     python3-venv \
@@ -98,7 +100,7 @@ echo
 if [ -f "$WORKSPACE/requirements.txt" ]; then
   echo ">>> Installing the Python requirements"
   python3 -m pip install --upgrade pip
-  pip3 install -e "$WORKSPACE"
+  pip3 install -e "$WORKSPACE" --no-deps
 else
   echo -e "${RED} ** ERROR: Failed to build & install audera.${RESET}"
   exit 1

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -48,6 +48,7 @@ fi
 echo ">>> Installing build packages"
 apt-get update && \
 apt-get install -y \
+    nmcli \
     alsa-utils \
     ffmpeg \
     shairport-sync \

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -12,6 +12,13 @@ YELLOW='\033[1;33m'
 GREEN='\033[0;32m'
 RESET='\033[0m'
 
+# Parse arguments
+if [ -n "$1" ]; then
+    GIT_BRANCH="$1"
+else
+    GIT_BRANCH="main"
+fi
+
 # Variables
 GIT_REPO_URL="https://github.com/thomaseleff/audera.git"
 WORKSPACE="/home/dietpi/audera"
@@ -74,10 +81,10 @@ echo -e "[  ${GREEN}OK${RESET}  ] Services disabled successfully"
 echo
 if [ ! -d "$WORKSPACE" ]; then
   echo ">>> Cloning the Git repository"
-  git clone -b main "$GIT_REPO_URL" "$WORKSPACE"
+  git clone -b "$GIT_BRANCH" "$GIT_REPO_URL" "$WORKSPACE"
 else
   echo ">>> Pulling the Git repository"
-  cd "$WORKSPACE" && git pull origin main
+  cd "$WORKSPACE" && git pull origin "$GIT_BRANCH"
 fi
 echo -e "[  ${GREEN}OK${RESET}  ] Git repository created successfully"
 

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -87,8 +87,8 @@ echo -e "[  ${GREEN}OK${RESET}  ] ifupdown purged successfully"
 
 # Setup network-manager
 
-# Network-manager should manage all devices, even those
-#   configured within `/etc/network/interfaces`.
+# Network-manager should manage all network devices,
+#   even those configured within `/etc/network/interfaces`.
 
 echo
 echo ">>> Setting up network-manager"

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -57,11 +57,11 @@ fi
 echo ">>> Installing build packages"
 apt-get update && \
 apt-get install -y \
+    network-manager \
+    dnsmasq \
     alsa-utils \
     ffmpeg \
     shairport-sync \
-    network-manager \
-    dnsmasq \
     git \
     python3.11 \
     python3-venv \
@@ -81,8 +81,12 @@ echo -e "[  ${GREEN}OK${RESET}  ] Packages installed successfully"
 
 echo
 echo ">>> Purging ifupdown"
-sudo systemctl stop ifupdown
-sudo systemctl disable ifupdown
+
+if sudo systemctl is-active --quiet ifupdown; then
+    sudo systemctl stop ifupdown
+    sudo systemctl disable ifupdown
+fi
+
 sudo apt-get purge -y ifupdown
 sudo sed -i '/^[[:space:]]*[^#[:space:]]/s/^/# /' /etc/network/interfaces
 echo -e "[  ${GREEN}OK${RESET}  ] ifupdown purged successfully"

--- a/os/dietpi/player/dietpi.txt
+++ b/os/dietpi/player/dietpi.txt
@@ -221,7 +221,7 @@ CONFIG_NTP_MODE=3
 CONFIG_SERIAL_CONSOLE_ENABLE=0
 
 # Sound card
-CONFIG_SOUNDCARD=rpi-bcm2835-auto
+CONFIG_SOUNDCARD=rpi-digiampplus
 
 # LCD Panel addon
 # - Do not modify, you must use dietpi-config to configure/set options

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ duckdb==1.1.3
 pytensils==1.3.0
 netifaces==0.11.0
 nicegui==2.11.1
-dotenv==0.9.9
+python-dotenv==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ duckdb==1.1.3
 pytensils==1.3.0
 netifaces==0.11.0
 nicegui==2.11.1
+dotenv==0.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ coolname==2.2.0
 duckdb==1.1.3
 pytensils==1.3.0
 netifaces==0.11.0
+nicegui==2.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ntplib==0.4.0
 zeroconf==0.136.2
 coolname==2.2.0
 duckdb==1.1.3
-pytensils==1.3.0
+pytensils==1.4.0
 netifaces==0.11.0
 nicegui==2.11.1
 python-dotenv==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     duckdb==1.1.3
     pytensils==1.3.0
     netifaces==0.11.0
+    nicegui==2.11.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     zeroconf==0.136.2
     coolname==2.2.0
     duckdb==1.1.3
-    pytensils==1.3.0
+    pytensils==1.4.0
     netifaces==0.11.0
     nicegui==2.11.1
     python-dotenv==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     pytensils==1.3.0
     netifaces==0.11.0
     nicegui==2.11.1
+    dotenv==0.9.9
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     pytensils==1.3.0
     netifaces==0.11.0
     nicegui==2.11.1
-    dotenv==0.9.9
+    python-dotenv==1.1.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
**Revisions**
- Adds a player-setup web-app that allows for renaming a remote audio output player and sharing Wi-Fi credentials. The UI will automatically start when the player does not have internet access. Once started, the player will host an access-point that can be connected to via another device.
- Adds an `ap` module for creating, deleting and managing access-points
- Modifies the immutability of the identity of an audera device so that once an identity is created, both the `name` and the `uuid` of that device remain unchanged forever, even if the mac-address and ip-address of the device changes.
- Fixes a bug issue where player configuration is not updated when a player identity is changed.