### PR TITLE
v0.9.0

### DIFF
--- a/audera/struct/audio.py
+++ b/audera/struct/audio.py
@@ -12,7 +12,7 @@ from pytensils import config
 # Interface configuration
 CHUNK: int = 1024
 FORMAT: int = pyaudio.paInt16
-CHANNELS: Literal[1, 2] = 2
+CHANNELS: Literal[1, 2] = 1
 RATE: Literal[5000, 8000, 11025, 22050, 44100, 48000, 92000] = 44100
 DEVICE_INDEX: int = 0
 _BITRATES = {

--- a/os/dietpi/player/conf/shairport-sync.conf
+++ b/os/dietpi/player/conf/shairport-sync.conf
@@ -28,7 +28,7 @@ general = {
 #	drift_tolerance_in_seconds = 0.002; # allow a timing error of this number of seconds of drift away from exact synchronisation before attempting to correct it
 #	resync_threshold_in_seconds = 0.050; # a synchronisation error greater than this number of seconds will cause resynchronisation; 0 disables it
 #	resync_recovery_time_in_seconds = 0.100; # allow this extra time to recover after a late resync. Increase the value, possibly to 0.5, in a virtual machine.
-#	playback_mode = "stereo"; # This can be "stereo", "mono", "reverse stereo", "both left" or "both right". Default is "stereo".
+	playback_mode = "mono"; # This can be "stereo", "mono", "reverse stereo", "both left" or "both right". Default is "stereo".
 #	alac_decoder = "hammerton"; # This can be "hammerton" or "apple". This advanced setting allows you to choose
 #		the original Shairport decoder by David Hammerton or the Apple Lossless Audio Codec (ALAC) decoder written by Apple.
 #		If you build Shairport Sync with the flag --with-apple-alac, the Apple ALAC decoder will be chosen by default.


### PR DESCRIPTION
**Revisions**
- Modifies the default num. channels for `mono` streaming and audio playback for both the `audera` and `shairport-sync` services (closes #20)