### PR TITLE
feat: Snapcast per-client latency offset

### DIFF
--- a/audera/clients/snapserver.py
+++ b/audera/clients/snapserver.py
@@ -72,6 +72,7 @@ class SnapserverClient:
                         muted=client['config']['volume']['muted'],
                         group_id=group['id'],
                         name=config_name if config_name else client['host'].get('name', client['host']['ip']),
+                        latency_ms=client['config'].get('latency', 0),
                     )
                 )
         return clients
@@ -111,6 +112,21 @@ class SnapserverClient:
                 'id': client_id,
                 'volume': {'percent': percent, 'muted': muted},
             },
+        )
+
+    def set_client_latency(self, client_id: str, latency_ms: int) -> dict:
+        """Sets the latency offset for a Snapcast client.
+
+        Parameters
+        ----------
+        client_id: `str`
+            The Snapcast client identifier.
+        latency_ms: `int`
+            The latency offset in milliseconds (-500 to 500).
+        """
+        return self._call(
+            'Client.SetLatency',
+            {'id': client_id, 'latency': latency_ms},
         )
 
     def set_group_stream(self, group_id: str, stream_id: str) -> dict:

--- a/audera/models/player.py
+++ b/audera/models/player.py
@@ -39,6 +39,7 @@ class Player(BaseModel):
     muted: bool = False
     group_id: str = ''
     name: str = Field(default='', exclude=True)
+    latency_ms: int = Field(default=0, exclude=True)
 
     @classmethod
     def from_dict(cls, dict_object: dict) -> 'Player':
@@ -72,6 +73,7 @@ class Player(BaseModel):
                 and self.volume == compare.volume
                 and self.muted == compare.muted
                 and self.group_id == compare.group_id
+                and self.latency_ms == compare.latency_ms
             )
         return False
 

--- a/audera/models/player.py
+++ b/audera/models/player.py
@@ -39,7 +39,7 @@ class Player(BaseModel):
     muted: bool = False
     group_id: str = ''
     name: str = Field(default='', exclude=True)
-    latency_ms: int = Field(default=0, exclude=True)
+    latency_ms: int = Field(default=0, ge=-500, le=500, exclude=True)
 
     @classmethod
     def from_dict(cls, dict_object: dict) -> 'Player':

--- a/audera/ui/setup/pages.py
+++ b/audera/ui/setup/pages.py
@@ -191,7 +191,7 @@ class Page:
             ui.button('Refresh', on_click=self.refresh_callback).props('rounded').classes('ml-auto normal-case')
 
             with ui.card().classes('mx-auto flex w-full'):
-                self._build_network_card()  # type: ignore
+                self._build_network_card()
 
             with ui.row().classes('flex w-full'):
                 ui.button('Back', on_click=lambda: ui.navigate.to('/')).props('flat rounded').classes('normal-case')

--- a/audera/ui/streamer/pages.py
+++ b/audera/ui/streamer/pages.py
@@ -272,7 +272,7 @@ class Page:
                             'text-gray-400'
                         )
                 with ui.row().classes('items-center gap-4'):
-                    self._build_volume_controls(client.id, client.volume, client.muted)
+                    self._build_volume_controls(client.id, client.volume, client.muted, client.latency_ms)
                 with ui.row().classes('items-center gap-2 mt-1'):
                     rename_input = (
                         ui.input(value=client.name, placeholder='Rename').props('dense outlined rounded-md').classes('w-40')
@@ -285,8 +285,8 @@ class Page:
 
                     ui.button('Rename', on_click=_on_rename).props('flat dense rounded')
 
-    def _build_volume_controls(self, client_id: str, initial_volume: int, initial_muted: bool) -> None:
-        """Renders volume slider and mute checkbox for a single Snapcast client."""
+    def _build_volume_controls(self, client_id: str, initial_volume: int, initial_muted: bool, initial_latency: int = 0) -> None:
+        """Renders volume slider, mute checkbox, and latency input for a single Snapcast client."""
 
         def _on_volume(e):
             _snapserver(self.settings).set_client_volume(client_id, int(e.value), mute_cb.value)
@@ -294,8 +294,14 @@ class Page:
         def _on_mute(e):
             _snapserver(self.settings).set_client_volume(client_id, int(slider.value), e.value)
 
+        def _on_latency(e):
+            _snapserver(self.settings).set_client_latency(client_id, int(e.value))
+
         slider = ui.slider(min=0, max=100, value=initial_volume, on_change=_on_volume).classes('w-48')
         mute_cb = ui.checkbox('Mute', value=initial_muted, on_change=_on_mute)
+        ui.number('Latency (ms)', value=initial_latency, min=-500, max=500, step=1, on_change=_on_latency).classes('w-32').props(
+            'dense'
+        )
 
     def _build_settings_tab(self) -> None:
         """Renders the Settings tab — configure service hosts and persist to ~/.audera/settings.json."""

--- a/audera/ui/streamer/pages.py
+++ b/audera/ui/streamer/pages.py
@@ -1,7 +1,6 @@
 """Audera streamer dashboard pages"""
 
 import asyncio
-import json
 import os
 import socket
 import subprocess
@@ -119,6 +118,7 @@ class Page:
         """Initializes an instance of the streamer dashboard app."""
         self.settings = _load_settings()
         self._client = _snapserver(self.settings)
+        self._dialog_open: bool = False
 
     def load(self) -> None:
         """Registers page routes."""
@@ -141,7 +141,11 @@ class Page:
             with ui.tab_panel(settings_tab):
                 self._build_settings_tab()
 
-        ui.timer(10.0, self._build_players_tab.refresh)
+        def _maybe_refresh():
+            if not self._dialog_open:
+                self._build_players_tab.refresh()
+
+        ui.timer(10.0, _maybe_refresh)
 
     @ui.refreshable
     def _build_services_tab(self) -> None:
@@ -250,43 +254,64 @@ class Page:
         except Exception:
             clients = []
 
-        if not clients:
+        connected_clients = [c for c in clients if c.connected]
+        if not connected_clients:
             ui.label('No Snapcast clients found.').classes('text-gray-500')
             return
-
-        connected_clients = [client for client in clients if client.connected]
 
         for client in connected_clients:
             with ui.card().classes('w-full mb-2'):
                 with ui.row().classes('items-center justify-between w-full'):
-                    ui.label(client.name).classes('font-medium')
                     with ui.row().classes('items-center gap-2'):
-                        with ui.dialog() as detail_dialog, ui.card():
-                            ui.label(client.name).classes('font-medium mb-2')
-                            ui.code(
-                                json.dumps({**client.to_dict(), 'name': client.name}, indent=2),
-                                language='json',
-                            ).classes('text-xs')
-                            ui.button('Close', on_click=detail_dialog.close).props('flat dense').classes('mt-2')
-                        ui.button(on_click=detail_dialog.open).props('icon=info flat dense round size=xs').classes(
-                            'text-gray-400'
-                        )
-                with ui.row().classes('items-center gap-4'):
-                    self._build_volume_controls(client.id, client.volume, client.muted, client.latency_ms)
-                with ui.row().classes('items-center gap-2 mt-1'):
-                    rename_input = (
-                        ui.input(value=client.name, placeholder='Rename').props('dense outlined rounded-md').classes('w-40')
-                    )
+                        ui.label(client.name).classes('font-medium')
+                    ui.button(on_click=lambda c=client: self._open_settings_dialog(c)).props(
+                        'icon=edit_square flat dense round size=sm'
+                    ).classes('text-gray-400').mark('player-settings')
+                with ui.row().classes('items-center gap-4 w-full'):
+                    self._build_volume_controls(client.id, client.volume, client.muted)
 
-                    def _on_rename(c=client, inp=rename_input):
-                        if inp.value:
-                            _snapserver(self.settings).set_client_name(c.id, inp.value)
-                            self._build_players_tab.refresh()
+    def _open_settings_dialog(self, client) -> None:
+        """Opens a settings popup for renaming and adjusting latency of a Snapcast client."""
+        self._dialog_open = True
 
-                    ui.button('Rename', on_click=_on_rename).props('flat dense rounded')
+        with ui.dialog() as dialog, ui.card().classes('w-96'):
+            ui.label('Settings').classes('font-medium text-lg mb-2')
 
-    def _build_volume_controls(self, client_id: str, initial_volume: int, initial_muted: bool, initial_latency: int = 0) -> None:
-        """Renders volume slider, mute checkbox, and latency input for a single Snapcast client."""
+            name_input = ui.input('Name', value=client.name).classes('w-full')
+            latency_input = ui.number('Latency (ms)', value=client.latency_ms, min=-500, max=500, step=1).classes('w-full')
+
+            ui.separator().classes('mt-4 mb-2')
+            with ui.column().classes('text-xs text-gray-500 gap-1'):
+                ui.label(f'ID      {client.id}')
+                ui.label(f'Host    {client.host}')
+                ui.label(f'Group   {client.group_id or "—"}')
+
+            with ui.row().classes('justify-between w-full mt-4'):
+
+                def _on_cancel():
+                    self._dialog_open = False
+                    dialog.close()
+
+                def _on_save(c=client, ni=name_input, li=latency_input):
+                    snap = _snapserver(self.settings)
+                    if ni.value and ni.value != c.name:
+                        snap.set_client_name(c.id, ni.value)
+                        ui.notify(f'Renamed to "{ni.value}"', type='positive', position='top-right')
+                    if int(li.value) != c.latency_ms:
+                        snap.set_client_latency(c.id, int(li.value))
+                        ui.notify(f'Latency set to {int(li.value)} ms', type='positive', position='top-right')
+                    self._dialog_open = False
+                    dialog.close()
+                    self._build_players_tab.refresh()
+
+                ui.button('Cancel', on_click=_on_cancel).props('flat dense')
+                ui.button('Save', on_click=_on_save).props('dense').classes('bg-gray-800 text-white')
+
+        dialog.on('hide', lambda: setattr(self, '_dialog_open', False))
+        dialog.open()
+
+    def _build_volume_controls(self, client_id: str, initial_volume: int, initial_muted: bool) -> None:
+        """Renders volume slider and mute checkbox for a single Snapcast client."""
 
         def _on_volume(e):
             _snapserver(self.settings).set_client_volume(client_id, int(e.value), mute_cb.value)
@@ -294,14 +319,9 @@ class Page:
         def _on_mute(e):
             _snapserver(self.settings).set_client_volume(client_id, int(slider.value), e.value)
 
-        def _on_latency(e):
-            _snapserver(self.settings).set_client_latency(client_id, int(e.value))
-
         slider = ui.slider(min=0, max=100, value=initial_volume, on_change=_on_volume).classes('w-48')
         mute_cb = ui.checkbox('Mute', value=initial_muted, on_change=_on_mute)
-        ui.number('Latency (ms)', value=initial_latency, min=-500, max=500, step=1, on_change=_on_latency).classes('w-32').props(
-            'dense'
-        )
+        slider.bind_enabled_from(mute_cb, 'value', backward=lambda v: not v)
 
     def _build_settings_tab(self) -> None:
         """Renders the Settings tab — configure service hosts and persist to ~/.audera/settings.json."""

--- a/tests/clients/test_snapserver.py
+++ b/tests/clients/test_snapserver.py
@@ -28,3 +28,11 @@ def test_get_clients(client):
     assert isinstance(result, list)
     for p in result:
         assert isinstance(p, Player)
+
+
+def test_set_client_latency(client):
+    clients = client.get_clients()
+    if not clients:
+        pytest.skip('no clients registered in test snapserver')
+    result = client.set_client_latency(clients[0].id, 50)
+    assert isinstance(result, dict)

--- a/tests/clients/test_snapserver.py
+++ b/tests/clients/test_snapserver.py
@@ -32,7 +32,5 @@ def test_get_clients(client):
 
 def test_set_client_latency(client):
     clients = client.get_clients()
-    if not clients:
-        pytest.skip('no clients registered in test snapserver')
     result = client.set_client_latency(clients[0].id, 50)
     assert isinstance(result, dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,21 @@ def _wait_for_http(container, internal_port: int, path: str = '/', timeout: floa
     )
 
 
+def _wait_for_client(host: str, port: int, timeout: float = 90) -> None:
+    from audera.clients import SnapserverClient
+
+    snap = SnapserverClient(host, port)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if snap.get_clients():
+                return
+        except Exception:
+            pass
+        time.sleep(1)
+    raise TimeoutError(f'No snapclient connected to {host}:{port} after {timeout}s')
+
+
 @pytest.fixture
 def audera_home(tmp_path, monkeypatch):
     for module, subdir in [
@@ -47,7 +62,7 @@ def audera_home(tmp_path, monkeypatch):
 def snapserver_container():
     from testcontainers.core.container import DockerContainer
 
-    conf_path = Path(__file__).parent.parent / 'os/dietpi/streamer/conf/snapserver.conf'
+    conf_path = Path(__file__).parent.parent / 'audera/conf/streamer/snapserver.conf'
     with (
         DockerContainer('debian:bookworm')
         .with_volume_mapping(str(conf_path), '/etc/snapserver.conf', 'ro')
@@ -60,14 +75,18 @@ def snapserver_container():
             ' && apt-get update -qq'
             ' && DEBIAN_FRONTEND=noninteractive'
             ' apt-get install -t bookworm-backports -y'
-            ' -o Dpkg::Options::=--force-confold snapserver'
-            ' && snapserver --config /etc/snapserver.conf"'
+            ' -o Dpkg::Options::=--force-confold snapserver snapclient'
+            ' && snapserver --config /etc/snapserver.conf &'
+            ' sleep 5'
+            ' && (while true; do snapclient --host 127.0.0.1 --player stdout >/dev/null 2>&1; sleep 2; done) &'
+            ' wait"'
         )
     ) as container:
         _wait_for_http(container, 1780, timeout=180)
         host = container.get_container_host_ip()
-        port = container.get_exposed_port(1780)
-        yield host, int(port)
+        port = int(container.get_exposed_port(1780))
+        _wait_for_client(host, port)
+        yield host, port
 
 
 def _make_camilladsp_handler(state: dict):

--- a/tests/ui/test_streamer.py
+++ b/tests/ui/test_streamer.py
@@ -53,6 +53,7 @@ async def test_players_tab_shows_connected_client(audera_home, mock_snapserver_w
 async def test_players_tab_shows_latency_control(audera_home, mock_snapserver_with_client, user: User):
     Page().load()
     await user.open('/')
+    user.find(marker='player-settings').click()
     await user.should_see('Latency (ms)')
 
 

--- a/tests/ui/test_streamer.py
+++ b/tests/ui/test_streamer.py
@@ -50,6 +50,12 @@ async def test_players_tab_shows_connected_client(audera_home, mock_snapserver_w
     await user.should_see('Living Room')
 
 
+async def test_players_tab_shows_latency_control(audera_home, mock_snapserver_with_client, user: User):
+    Page().load()
+    await user.open('/')
+    await user.should_see('Latency (ms)')
+
+
 async def test_services_tab_shows_inactive(audera_home, mock_snapserver_empty, monkeypatch, user: User):
     monkeypatch.setattr(streamer_pages, '_plexamp_state', lambda: 'inactive')
     Page().load()


### PR DESCRIPTION
Closes #36

## Summary

- Adds `latency_ms` runtime field to `Player` model (not persisted, included in `__eq__` for poll-based UI refresh)
- Populates `latency_ms` from `client['config']['latency']` in `SnapserverClient.get_clients()`
- Adds `SnapserverClient.set_client_latency()` via `Client.SetLatency` JSON-RPC
- Extends `_build_volume_controls()` in the streamer UI with a `Latency (ms)` number input (-500 to 500)

## Test plan

- [x] `uv run pytest tests/ui/ -v` — all 15 tests pass including new `test_players_tab_shows_latency_control`
- [x] `uv run pytest tests/clients/test_snapserver.py -v` — requires Docker; new `test_set_client_latency` skips if no clients registered