### PR TITLE
fix: Pi 5 HDMI audio — wrong overlay + raw hw:0 playback

### DIFF
--- a/audera/cli/audera.py
+++ b/audera/cli/audera.py
@@ -70,6 +70,11 @@ def main():
         default='S32LE',
         help='CamillaDSP playback device format (camilladsp.yml only).',
     )
+    _STREAMER_CONF_PARSER.add_argument(
+        '--playback-device',
+        default='hw:0',
+        help='CamillaDSP playback ALSA device (camilladsp.yml only).',
+    )
     _STREAMER_CONF_PARSER.set_defaults(func=commands.streamer_conf)
 
     _STREAMER_UNITS_PARSER = _STREAMER_VERB_SUBPARSER.add_parser(
@@ -126,6 +131,11 @@ def main():
         choices=['S16LE', 'S32LE'],
         default='S32LE',
         help='CamillaDSP playback device format (camilladsp.yml only).',
+    )
+    _PLAYER_CONF_PARSER.add_argument(
+        '--playback-device',
+        default='hw:0',
+        help='CamillaDSP playback ALSA device (camilladsp.yml only).',
     )
     _PLAYER_CONF_PARSER.set_defaults(func=commands.player_conf)
 

--- a/audera/cli/commands.py
+++ b/audera/cli/commands.py
@@ -61,7 +61,7 @@ def player_start(**_) -> None:
         setup.run(role='player')
 
 
-def _emit_conf(filename: str, playback_format: Literal['S16LE', 'S32LE']) -> None:
+def _emit_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'], playback_device: str = 'hw:0') -> None:
     """Writes a bundled config file, rendered from `audera.cli.conf`, to stdout.
 
     Parameters
@@ -70,9 +70,11 @@ def _emit_conf(filename: str, playback_format: Literal['S16LE', 'S32LE']) -> Non
         The config file name to render.
     playback_format : `Literal['S16LE', 'S32LE']`
         The CamillaDSP playback device format (only applies to `camilladsp.yml`).
+    playback_device : `str`
+        The CamillaDSP playback ALSA device (only applies to `camilladsp.yml`).
     """
     if filename == 'camilladsp.yml':
-        sys.stdout.write(conf.render_camilladsp(playback_format))
+        sys.stdout.write(conf.render_camilladsp(playback_format, playback_device))
     elif filename == 'snapserver.conf':
         # The recorded enabled set, not `DEFAULT_ENABLED`. `~/.audera/sources.json` survives a
         # reprovision, so rendering the bootstrap default would ship a conf naming AirPlay to a
@@ -87,7 +89,9 @@ def _emit_conf(filename: str, playback_format: Literal['S16LE', 'S32LE']) -> Non
         raise SystemExit(f'Unknown config file: {filename!r}')
 
 
-def streamer_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32LE', **_) -> None:
+def streamer_conf(
+    filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32LE', playback_device: str = 'hw:0', **_
+) -> None:
     """Prints a bundled streamer config file to stdout.
 
     Parameters
@@ -96,10 +100,12 @@ def streamer_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S
         The config file name.
     playback_format : `Literal['S16LE', 'S32LE']`
         The CamillaDSP playback device format (only applies to `camilladsp.yml`).
+    playback_device : `str`
+        The CamillaDSP playback ALSA device (only applies to `camilladsp.yml`).
 
     Help
     ----
-    usage: audera streamer conf <filename> [--playback-format {S16LE,S32LE}]
+    usage: audera streamer conf <filename> [--playback-format {S16LE,S32LE}] [--playback-device DEVICE]
 
     Execute `audera streamer --help` for help.
 
@@ -110,7 +116,7 @@ def streamer_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S
     ```
 
     """
-    _emit_conf(filename, playback_format)
+    _emit_conf(filename, playback_format, playback_device)
 
 
 def streamer_units(disabled: bool = False, **_) -> None:
@@ -143,7 +149,7 @@ def streamer_units(disabled: bool = False, **_) -> None:
     sys.stdout.writelines(f'{unit}\n' for unit in source_units(sources_dal.get_enabled(), enabled=not disabled))
 
 
-def player_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32LE', **_) -> None:
+def player_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32LE', playback_device: str = 'hw:0', **_) -> None:
     """Prints a bundled player config file to stdout.
 
     Parameters
@@ -152,10 +158,12 @@ def player_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32
         The config file name.
     playback_format : `Literal['S16LE', 'S32LE']`
         The CamillaDSP playback device format (only applies to `camilladsp.yml`).
+    playback_device : `str`
+        The CamillaDSP playback ALSA device (only applies to `camilladsp.yml`).
 
     Help
     ----
-    usage: audera player conf <filename> [--playback-format {S16LE,S32LE}]
+    usage: audera player conf <filename> [--playback-format {S16LE,S32LE}] [--playback-device DEVICE]
 
     Execute `audera player --help` for help.
 
@@ -166,4 +174,4 @@ def player_conf(filename: str, playback_format: Literal['S16LE', 'S32LE'] = 'S32
     ```
 
     """
-    _emit_conf(filename, playback_format)
+    _emit_conf(filename, playback_format, playback_device)

--- a/audera/cli/conf.py
+++ b/audera/cli/conf.py
@@ -15,7 +15,7 @@ from audera.domains.sources import default_source, source_lines
 SNAPSERVER_CONF: str = '/etc/snapserver.conf'
 
 
-def render_camilladsp(playback_format: Literal['S16LE', 'S32LE'] = 'S32LE') -> str:
+def render_camilladsp(playback_format: Literal['S16LE', 'S32LE'] = 'S32LE', playback_device: str = 'hw:0') -> str:
     """Renders the CamillaDSP configuration file.
 
     Parameters
@@ -26,6 +26,10 @@ def render_camilladsp(playback_format: Literal['S16LE', 'S32LE'] = 'S32LE') -> s
         effective ceiling is 16-bit/48 kHz (ADR 002), so ``'S16LE'`` loses no
         quality. The capture device stays ``'S32LE'`` to match Snapclient's
         32-bit loopback output.
+    playback_device : `str`
+        The ALSA playback device. Defaults to ``'hw:0'``. Pi 5 HDMI requires
+        ``'plughw:0'`` because vc4-hdmi accepts only ``IEC958_SUBFRAME_LE``
+        (see ADR 003, decision 5).
 
     Returns
     -------
@@ -73,7 +77,7 @@ devices:
   playback:
     type: Alsa
     channels: 2
-    device: "hw:0" # Must match the DAC soundcard index
+    device: "{playback_device}"
     format: {playback_format}
 
 # Essential even if empty for the config to be valid

--- a/docs/adrs/001-raspberry-pi-hardware-assumptions.md
+++ b/docs/adrs/001-raspberry-pi-hardware-assumptions.md
@@ -24,6 +24,10 @@ Using a different DAC requires:
 - Updating the CamillaDSP `playback.device` in `audera/cli/conf.py` (`render_camilladsp`)
 - Verifying the ALSA card index does not shift when `snd-aloop` is loaded at `index=7`
 
+### HDMI audio (Pi 5)
+
+Pi 5 has no `snd_bcm2835`; firmware-KMS (`vc4-fkms-v3d`) binds video-only and enumerates no HDMI audio card. Pi 5 requires full KMS (`vc4-kms-v3d`) for HDMI audio enumeration, and `plughw:0` for playback because the vc4-hdmi ALSA device accepts only `IEC958_SUBFRAME_LE`. Provisioning auto-detects the board model via `/proc/device-tree/model` and applies the correct overlay and playback device. Pi 4 is unaffected — `vc4-fkms-v3d` + `hw:0` remain correct. Non-HDMI DACs are unaffected on both boards.
+
 ### OS: DietPi (Debian Trixie, Raspberry Pi OS-based image)
 
 `setup.sh` sources `/boot/dietpi/func/dietpi-globals` for `G_CONFIG_INJECT` and `dietpi-set_hardware`. These functions do not exist on standard Debian or Raspberry Pi OS. The automated first-boot flow (`AUTO_SETUP_*` keys in `dietpi.txt`) is also DietPi-specific.

--- a/docs/adrs/003-camilladsp-signal-chain-configuration.md
+++ b/docs/adrs/003-camilladsp-signal-chain-configuration.md
@@ -53,6 +53,8 @@ The pipeline is currently empty (`filters: {}`, `pipeline: []`). When filters ar
 
 Both player and streamer configs use `device: "hw:0"`. ADR 001 noted `hw:0,0` for the player historically; this has been unified to `hw:0` for consistency with the streamer. The `,0` sub-device specifier is redundant for the DigiAMP+ and ALSA resolves both forms to the same device node.
 
+**Pi 5 HDMI exception:** Pi 5's vc4-hdmi ALSA device accepts only `IEC958_SUBFRAME_LE`. CamillaDSP emits linear PCM (`S16LE`/`S32LE`), so every format open on `hw:0` returns `EINVAL`. Using `plughw:0` pulls in ALSA's `iec958` plugin automatically — no resampling, negligible CPU, no quality loss. Provisioning auto-detects the board model (`is_pi5()` in `os/dietpi/lib/config.sh`) and passes `--playback-device plughw:0` to the CLI's `conf camilladsp.yml` command. Pi 4 and all non-HDMI DACs remain on `hw:0`.
+
 ### 6. HDMI playback uses `S16LE`
 
 The `playback.format` defaults to `S32LE`, but HDMI sinks (TVs, AVRs) frequently reject 32-bit PCM and respond with silence or dropouts. When the attached audio device is HDMI, `playback.format` is set to `S16LE` instead.

--- a/docs/dev/PROVISION.md
+++ b/docs/dev/PROVISION.md
@@ -50,7 +50,7 @@ Run the script from the project root using Git's bundled bash.
 | `-u, --user` | `root` | SSH user |
 | `-p, --port` | `22` | SSH port |
 | `-i, --identity` | | SSH private key file |
-| `-a, --audio-device` | | Configure `dtoverlay` for the attached audio device: `hdmi`, `digiamp-plus`, `dac-plus`, `hifiberry-dac-plus`. Unset leaves the existing `dtoverlay` untouched. `hdmi` additionally uses firmware-KMS (`dtoverlay=vc4-fkms-v3d`) so the legacy `hdmi_*` settings apply, and renders the CamillaDSP playback format as `S16LE` (many HDMI sinks reject `S32LE`). |
+| `-a, --audio-device` | | Configure `dtoverlay` for the attached audio device: `hdmi`, `digiamp-plus`, `dac-plus`, `hifiberry-dac-plus`. Unset leaves the existing `dtoverlay` untouched. `hdmi` renders the CamillaDSP playback format as `S16LE` (many HDMI sinks reject `S32LE`). On Pi 4, it uses firmware-KMS (`dtoverlay=vc4-fkms-v3d`) with the legacy `hdmi_*` settings and `hw:0`. On Pi 5, it uses full KMS (`dtoverlay=vc4-kms-v3d`) and `plughw:0` (vc4-hdmi accepts only `IEC958_SUBFRAME_LE`). Board model is auto-detected. |
 | `--no-reboot` | | Skip final reboot; leaves device running for inspection |
 | `--wipe-networks` | | Delete all NetworkManager connections before reboot (triggers WiFi wizard on next boot) |
 | `-l, --log` | | Tee session output to a local file |

--- a/os/dietpi/lib/config.sh
+++ b/os/dietpi/lib/config.sh
@@ -31,6 +31,11 @@ set_cmdline_param() {
     fi
 }
 
+# Returns true when the host is a Raspberry Pi 5
+is_pi5() {
+    grep -q 'Raspberry Pi 5' /proc/device-tree/model 2>/dev/null
+}
+
 # Configures /boot/firmware/config.txt (and cmdline.txt, for hdmi) for the given
 #   audio device; a no-op (with a message) when $1 is empty
 configure_audio_device() {
@@ -42,14 +47,19 @@ configure_audio_device() {
     echo ">>> Configuring audio device: $audio_device"
     case "$audio_device" in
         hdmi)
-            set_config_line /boot/firmware/config.txt 'hdmi_force_hotplug' 'hdmi_force_hotplug=1'
-            set_config_line /boot/firmware/config.txt 'hdmi_drive' 'hdmi_drive=2'
-            set_config_line /boot/firmware/config.txt 'hdmi_force_edid_audio' 'hdmi_force_edid_audio=1'
-            set_config_line /boot/firmware/config.txt 'hdmi_group' 'hdmi_group=1'
-            set_config_line /boot/firmware/config.txt 'hdmi_mode' 'hdmi_mode=16'
-            set_config_line /boot/firmware/config.txt 'dtoverlay' 'dtoverlay=vc4-fkms-v3d'
-            set_config_line /boot/firmware/config.txt 'dtparam=audio' 'dtparam=audio=on'
-            set_cmdline_param /boot/firmware/cmdline.txt 'vc4\.force_hotplug' 'vc4.force_hotplug=3'
+            if is_pi5; then
+                set_config_line /boot/firmware/config.txt 'dtoverlay' 'dtoverlay=vc4-kms-v3d'
+                set_config_line /boot/firmware/config.txt 'dtparam=audio' 'dtparam=audio=on'
+            else
+                set_config_line /boot/firmware/config.txt 'hdmi_force_hotplug' 'hdmi_force_hotplug=1'
+                set_config_line /boot/firmware/config.txt 'hdmi_drive' 'hdmi_drive=2'
+                set_config_line /boot/firmware/config.txt 'hdmi_force_edid_audio' 'hdmi_force_edid_audio=1'
+                set_config_line /boot/firmware/config.txt 'hdmi_group' 'hdmi_group=1'
+                set_config_line /boot/firmware/config.txt 'hdmi_mode' 'hdmi_mode=16'
+                set_config_line /boot/firmware/config.txt 'dtoverlay' 'dtoverlay=vc4-fkms-v3d'
+                set_config_line /boot/firmware/config.txt 'dtparam=audio' 'dtparam=audio=on'
+                set_cmdline_param /boot/firmware/cmdline.txt 'vc4\.force_hotplug' 'vc4.force_hotplug=3'
+            fi
             ;;
         digiamp-plus)
             set_config_line /boot/firmware/config.txt 'dtoverlay' 'dtoverlay=rpi-digiampplus'
@@ -75,4 +85,10 @@ configure_audio_device() {
 #   (which reject S32LE), S32LE otherwise
 camilladsp_playback_format() {
     if [ "$1" = 'hdmi' ]; then echo 'S16LE'; else echo 'S32LE'; fi
+}
+
+# Echoes the CamillaDSP playback ALSA device for the given audio device: plughw:0 for
+#   Pi 5 + hdmi (vc4-hdmi accepts only IEC958_SUBFRAME_LE), hw:0 otherwise
+camilladsp_playback_device() {
+    if [ "$1" = 'hdmi' ] && is_pi5; then echo 'plughw:0'; else echo 'hw:0'; fi
 }

--- a/os/dietpi/player/automation/setup.sh
+++ b/os/dietpi/player/automation/setup.sh
@@ -92,7 +92,8 @@ echo -e "[  ${GREEN}OK${RESET}  ] audera installed successfully"
 echo
 echo ">>> Creating the CamillaDSP configuration"
 audera player conf camilladsp.yml \
-    --playback-format "$(camilladsp_playback_format "$AUDIO_DEVICE")" > "$CAMILLADSP_CONFIG"
+    --playback-format "$(camilladsp_playback_format "$AUDIO_DEVICE")" \
+    --playback-device "$(camilladsp_playback_device "$AUDIO_DEVICE")" > "$CAMILLADSP_CONFIG"
 chmod 644 "$CAMILLADSP_CONFIG"
 echo -e "[  ${GREEN}OK${RESET}  ] CamillaDSP configured successfully"
 

--- a/os/dietpi/streamer/automation/setup.sh
+++ b/os/dietpi/streamer/automation/setup.sh
@@ -229,7 +229,8 @@ fi
 echo
 echo ">>> Creating the CamillaDSP configuration"
 audera streamer conf camilladsp.yml \
-    --playback-format "$(camilladsp_playback_format "$AUDIO_DEVICE")" > "$CAMILLADSP_CONFIG"
+    --playback-format "$(camilladsp_playback_format "$AUDIO_DEVICE")" \
+    --playback-device "$(camilladsp_playback_device "$AUDIO_DEVICE")" > "$CAMILLADSP_CONFIG"
 chmod 644 "$CAMILLADSP_CONFIG"
 echo -e "[  ${GREEN}OK${RESET}  ] CamillaDSP configured successfully"
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -153,3 +153,17 @@ def test_conf_camilladsp_s16le_only_changes_playback(audera_cli, subject):
     assert out.count('format: S32LE') == 1
     # Comments are preserved end-to-end (scope + render fidelity).
     assert 'HDMI STABILITY' in out
+
+
+@pytest.mark.parametrize('subject', ['streamer', 'player'])
+def test_conf_camilladsp_default_playback_device_is_hw0(audera_cli, subject):
+    out = audera_cli(subject, 'conf', 'camilladsp.yml').stdout
+    assert '    device: "hw:0"\n' in out
+
+
+@pytest.mark.parametrize('subject', ['streamer', 'player'])
+def test_conf_camilladsp_playback_device_override(audera_cli, subject):
+    out = audera_cli(subject, 'conf', 'camilladsp.yml', '--playback-device', 'plughw:0').stdout
+    # Playback device becomes plughw:0; capture device stays hw:Loopback,1.
+    assert '    device: "plughw:0"\n' in out
+    assert '    device: "hw:Loopback,1"\n' in out


### PR DESCRIPTION
## Summary

- Pi 5 HDMI provisioning now auto-detects the board model and applies full KMS (`vc4-kms-v3d`) instead of firmware-KMS, which enumerates no HDMI audio card on Pi 5
- Adds `--playback-device` CLI argument so provisioning can pass `plughw:0` for Pi 5 HDMI (vc4-hdmi accepts only `IEC958_SUBFRAME_LE`, rejecting CamillaDSP's linear PCM on `hw:0`)
- Pi 4 and non-HDMI DACs are unchanged

## Test plan

- [x] `uv run pytest tests/cli/test_commands.py -v` — 21/21 pass, including 4 new `--playback-device` tests
- [x] `uv run ruff check --fix` — all checks passed
- [x] `uv run ruff format` — clean
- [x] `uv run ty check` — all checks passed
- [x] Flash a Pi 5 with `-a hdmi` and confirm HDMI audio plays end-to-end

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)