### PR TITLE
fix(website): point docs links at main

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -242,7 +242,7 @@
             <span class="nav__mark">Audera</span>
             <nav class="nav__links">
                 <a
-                    href="https://github.com/Eleff-org/audera/blob/remove-fragility-and-complexity/docs/README.md">Docs</a>
+                    href="https://github.com/Eleff-org/audera/blob/main/docs/README.md">Docs</a>
                 <a href="https://github.com/Eleff-org/audera">GitHub ↗</a>
             </nav>
         </header>
@@ -275,7 +275,7 @@
 
                 <div class="cta-row">
                     <a class="cta"
-                        href="https://github.com/Eleff-org/audera/blob/remove-fragility-and-complexity/docs/getting-started.md">Get
+                        href="https://github.com/Eleff-org/audera/blob/main/docs/getting-started.md">Get
                         started →</a>
                 </div>
             </div>


### PR DESCRIPTION
The two docs links in `website/index.html` (header **Docs** and the **Get started** CTA) still referenced the `remove-fragility-and-complexity` feature branch. Repoint them to `main` so the published site links to stable paths.

Follow-up to #67, which was merged before these links were corrected. That PR is merged and can't be reopened, so this lands the remaining fix as its own PR.

## Changes
- `website/index.html`: `blob/remove-fragility-and-complexity/...` → `blob/main/...` for `docs/README.md` and `docs/getting-started.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)