### PR TITLE
feat(settings): add reference balance save and restore

### DIFF
--- a/audera/dal/__init__.py
+++ b/audera/dal/__init__.py
@@ -1,5 +1,5 @@
 """Data-access layer"""
 
-from audera.dal import dsp, presets, settings, sources, volume
+from audera.dal import balance, dsp, presets, settings, sources, volume
 
-__all__ = ['dsp', 'presets', 'settings', 'sources', 'volume']
+__all__ = ['balance', 'dsp', 'presets', 'settings', 'sources', 'volume']

--- a/audera/dal/balance.py
+++ b/audera/dal/balance.py
@@ -8,6 +8,8 @@ import logging
 import os
 from typing import Callable, Union
 
+from pydantic import ValidationError
+
 from audera import io
 from audera.dal import path
 from audera.errors import StorageError
@@ -45,15 +47,16 @@ def get() -> balance.ReferenceBalance:
     Raises
     ------
     `audera.errors.StorageError`
-        When the reference-balance file cannot be read or holds invalid JSON.
+        When the reference-balance file cannot be read, holds invalid JSON, or is missing the
+        expected keys or shape.
     """
     file_path = os.path.join(PATH, FILE_NAME)
     try:
         with open(file_path, 'r') as f:
             data = json.load(f)
-    except (OSError, ValueError) as exc:
+        return balance.ReferenceBalance.model_validate(data['balance'])
+    except (OSError, ValueError, KeyError, ValidationError) as exc:
         raise StorageError('Unable to read reference balance [%s]: %s' % (file_path, exc)) from exc
-    return balance.ReferenceBalance.model_validate(data['balance'])
 
 
 def save(ref: balance.ReferenceBalance) -> balance.ReferenceBalance:

--- a/audera/dal/balance.py
+++ b/audera/dal/balance.py
@@ -1,0 +1,69 @@
+"""Reference-balance configuration-layer
+
+One reference balance under `~/.audera/balance.json`: `save` overwrites it, `get` re-reads it.
+"""
+
+import json
+import logging
+import os
+from typing import Callable, Union
+
+from audera import io
+from audera.dal import path
+from audera.errors import StorageError
+from audera.models import balance
+
+logger = logging.getLogger(__name__)
+
+PATH: Union[str, os.PathLike] = path.HOME
+FILE_NAME: str = 'balance.json'
+
+_observers: list[Callable[[], None]] = []
+
+
+def on_change(callback: Callable[[], None]) -> None:
+    """Registers a callback invoked after a reference-balance save."""
+    _observers.append(callback)
+
+
+def _notify_observers() -> None:
+    for cb in _observers:
+        try:
+            cb()
+        except Exception:
+            logger.exception('balance observer failed')
+
+
+def exists() -> bool:
+    """Returns `True` when the reference-balance file exists."""
+    return os.path.isfile(os.path.abspath(os.path.join(PATH, FILE_NAME)))
+
+
+def get() -> balance.ReferenceBalance:
+    """Returns the saved reference balance as a `ReferenceBalance` object.
+
+    Raises
+    ------
+    `audera.errors.StorageError`
+        When the reference-balance file cannot be read or holds invalid JSON.
+    """
+    file_path = os.path.join(PATH, FILE_NAME)
+    try:
+        with open(file_path, 'r') as f:
+            data = json.load(f)
+    except (OSError, ValueError) as exc:
+        raise StorageError('Unable to read reference balance [%s]: %s' % (file_path, exc)) from exc
+    return balance.ReferenceBalance.model_validate(data['balance'])
+
+
+def save(ref: balance.ReferenceBalance) -> balance.ReferenceBalance:
+    """Saves the reference balance to `~/.audera/balance.json`.
+
+    Parameters
+    ----------
+    ref: `audera.models.balance.ReferenceBalance`
+        An instance of a `ReferenceBalance` object.
+    """
+    io.write_text(os.path.join(PATH, FILE_NAME), json.dumps({'balance': ref.model_dump()}, indent=2))
+    _notify_observers()
+    return ref

--- a/audera/dal/dsp.py
+++ b/audera/dal/dsp.py
@@ -5,6 +5,8 @@ import logging
 import os
 from typing import Union
 
+from pydantic import ValidationError
+
 from audera import io
 from audera.dal import path
 from audera.errors import StorageError
@@ -48,15 +50,16 @@ def get(player_id: str) -> dsp.DSPConfig:
     Raises
     ------
     `audera.errors.StorageError`
-        When the DSP file cannot be read or holds invalid JSON.
+        When the DSP file cannot be read, holds invalid JSON, or is missing the expected keys or
+        shape.
     """
     file_path = os.path.join(PATH, path.to_filename(player_id))
     try:
         with open(file_path, 'r') as f:
             data = json.load(f)
-    except (OSError, ValueError) as exc:
+        return dsp.DSPConfig.model_validate(data['dsp'])
+    except (OSError, ValueError, KeyError, ValidationError) as exc:
         raise StorageError('Unable to read DSP configuration [%s]: %s' % (file_path, exc)) from exc
-    return dsp.DSPConfig.model_validate(data['dsp'])
 
 
 def get_or_create(dsp_config: dsp.DSPConfig) -> dsp.DSPConfig:

--- a/audera/dal/settings.py
+++ b/audera/dal/settings.py
@@ -5,6 +5,8 @@ import logging
 import os
 from typing import Callable, Union
 
+from pydantic import ValidationError
+
 from audera import io
 from audera.dal import path
 from audera.errors import StorageError
@@ -53,15 +55,16 @@ def get() -> settings.Settings:
     Raises
     ------
     `audera.errors.StorageError`
-        When the settings file cannot be read or holds invalid JSON.
+        When the settings file cannot be read, holds invalid JSON, or is missing the expected
+        keys or shape.
     """
     file_path = os.path.join(PATH, FILE_NAME)
     try:
         with open(file_path, 'r') as f:
             data = json.load(f)
-    except (OSError, ValueError) as exc:
+        return settings.Settings.model_validate(data['settings'])
+    except (OSError, ValueError, KeyError, ValidationError) as exc:
         raise StorageError('Unable to read settings [%s]: %s' % (file_path, exc)) from exc
-    return settings.Settings.model_validate(data['settings'])
 
 
 def get_or_create(settings_: settings.Settings) -> settings.Settings:

--- a/audera/models/balance.py
+++ b/audera/models/balance.py
@@ -1,0 +1,17 @@
+"""Reference-balance snapshot"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ReferenceBalance(BaseModel):
+    """A saved snapshot of per-player volume percents, keyed on Snapcast player id.
+
+    Attributes
+    ----------
+    volumes: `dict[str, int]`
+        A mapping of Snapcast player id to its saved volume percent (0-100).
+    """
+
+    volumes: dict[str, int] = Field(default_factory=dict)

--- a/audera/ui/AGENTS.md
+++ b/audera/ui/AGENTS.md
@@ -45,6 +45,8 @@ UI code never calls `subprocess`; every systemd interaction goes through `audera
 
 `streamer/broker.py` brokers Snapserver and volume-DAL events into a cache the UI reads synchronously; `streamer/commands.py` serializes every write path through one `asyncio.Queue`. Both are module-level singletons started on app startup and torn down on shutdown; their module docstrings own the details (seed-then-delta, debounce, reconnect, coalescing).
 
+Any DAL write whose result is reflected in a tab must fan out to every connected browser through the observer layer, not just `refresh()` the acting page — see ADR 005 §10. A new write path exposes `on_change` / `_notify_observers` on its DAL and a handler in `streamer/__init__.py` that refreshes the affected tabs on each `connected_pages()` entry, honoring `page._dialog_open` / `_deferred_tabs`.
+
 ## Previewing and running locally
 
 The user iterates on UI from screenshots. Most player UI needs live Snapcast clients, so:

--- a/audera/ui/streamer/__init__.py
+++ b/audera/ui/streamer/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 from nicegui import app, ui
 
 import audera
+from audera.dal import balance as balance_dal
 from audera.dal import settings as settings_dal
 from audera.dal import sources as sources_dal
 from audera.dal import volume as volume_dal
@@ -28,7 +29,12 @@ def _stream_status_key() -> tuple[tuple[str, str], ...]:
 
 
 def _on_dirty() -> None:
-    """Fan-out: rebuild Players on every dirty; rebuild Sources only when stream_status changed."""
+    """Fan-out: rebuild Players and Settings on every dirty; rebuild Sources only when
+    stream_status changed.
+
+    Settings rebuilds on every dirty so its "Listening at reference" indicator tracks live volume
+    and connection changes.
+    """
     global _prev_stream_status
     stream_key = _stream_status_key()
     streams_changed = stream_key != _prev_stream_status
@@ -37,12 +43,13 @@ def _on_dirty() -> None:
 
     for client, page in connected_pages():
         if page._dialog_open:
-            page._deferred_tabs.add('players')
+            page._deferred_tabs.update(('players', 'settings'))
             if streams_changed:
                 page._deferred_tabs.add('sources')
             continue
         with client:
             page._build_players_tab.refresh()
+            page._build_settings_tab.refresh()
             if streams_changed:
                 page._build_sources_tab.refresh()
 
@@ -83,8 +90,34 @@ def _on_settings_changed() -> None:
     _loop.call_soon_threadsafe(_apply)
 
 
+def _on_balance_changed() -> None:
+    """Refresh the Settings tab on every connected client after a reference-balance save.
+
+    A save changes no volumes, so only the Settings tab (its Restore button and "Listening at
+    reference" indicator) needs to rebuild.
+    """
+    if _loop is None:
+        return
+
+    def _apply():
+        for client, page in connected_pages():
+            if page._dialog_open:
+                page._deferred_tabs.add('settings')
+                continue
+            with client:
+                page._build_settings_tab.refresh()
+
+    _loop.call_soon_threadsafe(_apply)
+
+
 def _on_volume_changed() -> None:
-    """Push DAL volumes into the broker cache so NiceGUI bindings propagate to sliders."""
+    """Push DAL volumes into the broker cache so NiceGUI bindings propagate to sliders, and
+    refresh the Settings tab so its "Listening at reference" indicator tracks every loudness
+    change (a normal loudness change produces no broker dirty).
+
+    Players are intentionally not rebuilt: sliders update purely via binding; only the small
+    Settings section rebuilds.
+    """
     if _loop is None:
         return
     try:
@@ -96,6 +129,12 @@ def _on_volume_changed() -> None:
     def _apply():
         for player_id, percent in cached.items():
             b.cache.volumes[player_id] = percent
+        for client, page in connected_pages():
+            if page._dialog_open:
+                page._deferred_tabs.add('settings')
+                continue
+            with client:
+                page._build_settings_tab.refresh()
 
     _loop.call_soon_threadsafe(_apply)
 
@@ -110,6 +149,7 @@ def _start() -> None:
     sources_dal.on_change(_on_sources_changed)
     settings_dal.on_change(_on_settings_changed)
     volume_dal.on_change(_on_volume_changed)
+    balance_dal.on_change(_on_balance_changed)
 
 
 def run() -> None:

--- a/audera/ui/streamer/pages/index.py
+++ b/audera/ui/streamer/pages/index.py
@@ -7,11 +7,13 @@ from typing import TYPE_CHECKING, Callable, NamedTuple
 from nicegui import ui
 
 import audera
+from audera.dal import balance as balance_dal
 from audera.dal import settings as settings_dal
 from audera.dal import sources as sources_dal
 from audera.dal import volume as volume_dal
 from audera.domains.sources import CATALOG, SourceDefinition, default_source, toggle
 from audera.errors import CommandError
+from audera.models.balance import ReferenceBalance
 from audera.models.player import Player
 from audera.models.settings import Settings
 from audera.ui import components, features
@@ -1444,6 +1446,17 @@ async def _reset_snap_volume(page: 'Page', client, vol_label=None) -> None:
     ui.notify('Snapcast volume reset to 100%', type='positive', position='top-right')
 
 
+def _apply_volume(settings: Settings, camilla, client_id: str, percent: int) -> None:
+    """Writes one player's volume through the triad: CamillaDSP (the real loudness), the volume
+    DAL, and the Snapcast 0/100 mute sidecar. The slider and Save/Restore share this path so the
+    three writes never drift.
+    """
+    camilla.set_percent_volume(percent)
+    volume_dal.set(client_id, percent)
+    muted = percent <= 0
+    _snapserver(settings).set_client_volume(client_id, 0 if muted else 100, muted=muted)
+
+
 def _build_volume_controls(
     page: 'Page',
     client_id: str,
@@ -1468,17 +1481,11 @@ def _build_volume_controls(
     camilla = _camilladsp(client_host) if client_host else _camilladsp('localhost')
     FF_VOLUME_PERC_OR_DB = features.flag_enabled(page.settings, features.VOLUME_KEY, features.FF_VOLUME_PERC_OR_DB)
 
-    def _write_volume(camilla_client, settings, cid, percent):
-        camilla_client.set_percent_volume(percent)
-        volume_dal.set(cid, percent)
-        muted = percent <= 0
-        _snapserver(settings).set_client_volume(cid, 0 if muted else 100, muted=muted)
-
     async def _persist_and_sync(e) -> None:
         percent = int(e.args)
         try:
             await commands.get().submit(
-                _write_volume, camilla, page.settings, client_id, percent, coalesce_key=('volume', client_id)
+                _apply_volume, page.settings, camilla, client_id, percent, coalesce_key=('volume', client_id)
             )
         except CommandError:
             pass
@@ -1520,8 +1527,42 @@ def _build_volume_controls(
     return slider
 
 
+def _at_reference() -> bool:
+    """Whether every connected player currently sits at its recorded reference volume.
+
+    ``False`` when no balance is saved, when no player is connected, or when any connected player
+    is missing from the balance or off its recorded percent.
+    """
+    if not balance_dal.exists():
+        return False
+    try:
+        ref = balance_dal.get().volumes
+    except CommandError:
+        return False
+    cache = broker.get().cache
+    connected = [player for player in cache.clients if player.connected]
+    if not connected:
+        return False
+    return all(player.id in ref and cache.volumes.get(player.id) == ref[player.id] for player in connected)
+
+
 def build_settings_tab(page: 'Page') -> None:
-    """Renders the Settings tab — one single-select button group per registered UX feature."""
+    """Renders the Settings tab — a reference-balance section, then one single-select button group
+    per registered UX feature."""
+    ui.label('Reference balance').classes('text-lg font-medium mb-2')
+    ui.label('Save and restore the current volume balance across all connected players.').classes('text-sm text-gray-500 mb-2')
+    # Indicator left, Save/Restore right, on one fixed-height row so the buttons stay put whether
+    # or not the indicator is lit.
+    with ui.row().classes('mb-4 w-full items-center justify-between h-9'):
+        with ui.row().classes('gap-1 items-center').mark('reference-status'):
+            if _at_reference():
+                ui.icon('circle').classes('text-green-500 text-xs')
+                ui.label('Listening at reference').classes('text-sm text-gray-500')
+        with ui.row().classes('gap-2'):
+            ui.button('Save', on_click=lambda: _on_save_reference_balance(page)).mark('save-reference')
+            restore = ui.button('Restore', on_click=lambda: _on_restore_reference_balance(page)).mark('restore-reference')
+            restore.set_enabled(balance_dal.exists())
+
     ui.label('Features').classes('text-lg font-medium mb-2')
     for feature in features.FEATURES:
         ui.label(feature.label).classes('text-sm text-gray-500')
@@ -1544,3 +1585,51 @@ async def _on_feature_change(page: 'Page', key: str, value: str) -> None:
         return
     page.settings = updated
     page._build_players_tab.refresh()
+
+
+async def _on_save_reference_balance(page: 'Page') -> None:
+    """Snapshots the current per-player volume balance and persists it as the reference balance."""
+    volumes = {player_id: percent for player_id, percent in broker.get().cache.volumes.items() if percent is not None}
+    ref = ReferenceBalance(volumes=volumes)
+    try:
+        await commands.get().submit(balance_dal.save, ref)
+    except CommandError:
+        ui.notify('Could not save reference balance', type='negative', position='top-right')
+        return
+    ui.notify('Saved reference balance', type='positive', position='top-right')
+    page._build_settings_tab.refresh()
+
+
+async def _on_restore_reference_balance(page: 'Page') -> None:
+    """Re-applies the saved reference balance to every connected player it names, skipping the rest."""
+    try:
+        ref = await asyncio.to_thread(balance_dal.get)
+    except CommandError:
+        ui.notify('Could not read reference balance', type='negative', position='top-right')
+        return
+
+    connected = [player for player in broker.get().cache.clients if player.connected]
+    restored = 0
+    for player in connected:
+        percent = ref.volumes.get(player.id)
+        if percent is None:
+            continue
+        try:
+            await commands.get().submit(
+                _apply_volume,
+                page.settings,
+                _camilladsp(player.host),
+                player.id,
+                percent,
+                coalesce_key=('volume', player.id),
+            )
+        except CommandError:
+            continue
+        restored += 1
+
+    page._build_players_tab.refresh()
+    ui.notify(
+        f'Restored balance for {restored} player{"" if restored == 1 else "s"}',
+        type='positive',
+        position='top-right',
+    )

--- a/docs/adrs/005-streamer-freshness-across-clients.md
+++ b/docs/adrs/005-streamer-freshness-across-clients.md
@@ -21,13 +21,13 @@ The streamer UI polled Snapserver every 10 seconds per browser, rebuilding the e
 
 6. **Step-aligned pushes.** Every value pushed to the volume slider is `int(round(…))`. An unaligned value makes Quasar snap the slider and emit a phantom `update:model-value`, echoing back to the device.
 
-7. **Defer and replay.** All three fan-out callbacks (broker dirty, sources observer, settings observer) check `page._dialog_open`; if true, they add the affected tab names to `page._deferred_tabs: set[str]` instead of refreshing. Every path that clears `_dialog_open` replays the deferred set — sources, settings, then players — and replaces it with a fresh empty set.
+7. **Defer and replay.** Every fan-out callback (broker dirty, plus the sources, settings, volume, and balance observers) checks `page._dialog_open`; if true, it adds the affected tab names to `page._deferred_tabs: set[str]` instead of refreshing. Every path that clears `_dialog_open` replays the deferred set — sources, settings, then players — and replaces it with a fresh empty set.
 
 8. **Debounce.** A burst of Snapserver notifications (e.g. a server restart) produces one callback invocation after a 250 ms quiet period, not one per notification.
 
 9. **Startup/shutdown lifecycle.** `broker.start` on `app.on_startup`, `broker.stop` on `app.on_shutdown`, both wired in `audera/ui/streamer/__init__.py`. DAL observers are registered alongside the broker.
 
-10. **Device-wide settings.** Sources and Settings DAL writes notify all connected browsers via a simple observer pattern (`on_change` / `_notify_observers`). Both observers respect `page._dialog_open`, deferring into `_deferred_tabs` the same way the broker's dirty callback does. A settings change reloads every page's `settings` from disk unconditionally (data, not UI) and refreshes both the Players and Settings tabs.
+10. **Fan out every UI-visible write.** Any DAL write whose result is reflected in a tab must expose the observer pattern (`on_change` / `_notify_observers`, notified at the end of `save`/`set`) and fan out through a handler in `ui/streamer/__init__.py` that marshals onto the UI loop and refreshes the affected tabs on every connected page. A local `refresh()` on the acting page is not sufficient — it leaves other browsers, and often the acting one, stale. This is an invariant, not a fixed list: a new write path adds an observer. Every observer respects `page._dialog_open`, deferring into `_deferred_tabs` the same way the broker's dirty callback does. Current observers: sources, settings, volume, balance. A settings change additionally reloads every page's `settings` from disk (data, not UI). A volume change pushes the DAL volumes into the broker cache for the slider bindings and refreshes Settings so the "Listening at reference" indicator tracks loudness changes that cross no Snapcast mute boundary (and therefore produce no broker dirty).
 
 ## Consequences
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ def _wait_for_client(host: str, port: int, timeout: float = 90) -> None:
 @pytest.fixture
 def audera_home(tmp_path, monkeypatch):
     for module, subdir in [
+        ('audera.dal.balance', 'balance'),
         ('audera.dal.dsp', 'dsp'),
         ('audera.dal.presets', 'dsp/presets'),
         ('audera.dal.settings', 'settings'),

--- a/tests/dal/test_balance.py
+++ b/tests/dal/test_balance.py
@@ -1,0 +1,61 @@
+import os
+
+import pytest
+
+import audera.dal.balance as balance_dal
+from audera.errors import StorageError
+from audera.models.balance import ReferenceBalance
+
+
+def _write_corrupt() -> str:
+    """Writes an unparseable reference-balance file and returns its path."""
+    os.makedirs(balance_dal.PATH, exist_ok=True)
+    file_path = os.path.join(balance_dal.PATH, balance_dal.FILE_NAME)
+    with open(file_path, 'w') as f:
+        f.write('{ not json')
+    return file_path
+
+
+def test_balance_absent_by_default(audera_home):
+    assert not balance_dal.exists()
+
+
+def test_balance_save_then_exists(audera_home):
+    balance_dal.save(ReferenceBalance(volumes={'aa:bb:cc:dd:ee:ff': 70}))
+    assert balance_dal.exists()
+
+
+def test_balance_round_trip(audera_home):
+    ref = ReferenceBalance(volumes={'player-1': 40, 'player-2': 60})
+    balance_dal.save(ref)
+    assert balance_dal.get() == ref
+
+
+def test_balance_save_overwrites(audera_home):
+    balance_dal.save(ReferenceBalance(volumes={'player-1': 40}))
+    balance_dal.save(ReferenceBalance(volumes={'player-2': 90}))
+    assert balance_dal.get().volumes == {'player-2': 90}
+
+
+def test_balance_mac_address_player_id(audera_home):
+    mac_id = 'aa:bb:cc:dd:ee:ff'
+    balance_dal.save(ReferenceBalance(volumes={mac_id: 55}))
+    assert balance_dal.get().volumes == {mac_id: 55}
+
+
+def test_balance_empty_round_trip(audera_home):
+    balance_dal.save(ReferenceBalance())
+    assert balance_dal.get().volumes == {}
+
+
+def test_balance_get_raises_storage_error_on_corrupt_file(audera_home):
+    _write_corrupt()
+    with pytest.raises(StorageError):
+        balance_dal.get()
+
+
+def test_save_notifies_observers(audera_home):
+    fired: list[bool] = []
+    balance_dal.on_change(lambda: fired.append(True))
+    balance_dal.save(ReferenceBalance(volumes={'player-1': 50}))
+    assert fired == [True]

--- a/tests/dal/test_balance.py
+++ b/tests/dal/test_balance.py
@@ -9,10 +9,15 @@ from audera.models.balance import ReferenceBalance
 
 def _write_corrupt() -> str:
     """Writes an unparseable reference-balance file and returns its path."""
+    return _write_raw('{ not json')
+
+
+def _write_raw(content: str) -> str:
+    """Writes arbitrary content to the reference-balance file and returns its path."""
     os.makedirs(balance_dal.PATH, exist_ok=True)
     file_path = os.path.join(balance_dal.PATH, balance_dal.FILE_NAME)
     with open(file_path, 'w') as f:
-        f.write('{ not json')
+        f.write(content)
     return file_path
 
 
@@ -50,6 +55,20 @@ def test_balance_empty_round_trip(audera_home):
 
 def test_balance_get_raises_storage_error_on_corrupt_file(audera_home):
     _write_corrupt()
+    with pytest.raises(StorageError):
+        balance_dal.get()
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        '{"other": {}}',  # valid JSON, missing the 'balance' key
+        '{"balance": null}',  # valid JSON, wrong shape for the model
+        '{"balance": {"volumes": "loud"}}',  # valid JSON, wrong field type
+    ],
+)
+def test_balance_get_raises_storage_error_on_wrong_shape_file(audera_home, content):
+    _write_raw(content)
     with pytest.raises(StorageError):
         balance_dal.get()
 

--- a/tests/dal/test_dsp.py
+++ b/tests/dal/test_dsp.py
@@ -9,12 +9,17 @@ from audera.models.dsp import Band, DSPConfig
 
 def _write_corrupt(player_id: str) -> str:
     """Writes an unparseable DSP file for `player_id` and returns its path."""
+    return _write_raw(player_id, '{ not json')
+
+
+def _write_raw(player_id: str, content: str) -> str:
+    """Writes arbitrary content to the DSP file for `player_id` and returns its path."""
     from audera.dal import path
 
     os.makedirs(dsp_dal.PATH, exist_ok=True)
     file_path = os.path.join(dsp_dal.PATH, path.to_filename(player_id))
     with open(file_path, 'w') as f:
-        f.write('{ not json')
+        f.write(content)
     return file_path
 
 
@@ -131,6 +136,20 @@ def test_dsp_get_or_create_idempotent_after_edit(audera_home):
 
 def test_dsp_get_raises_storage_error_on_corrupt_file(audera_home):
     _write_corrupt('abc123')
+    with pytest.raises(StorageError):
+        dsp_dal.get('abc123')
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        '{"other": {}}',  # valid JSON, missing the 'dsp' key
+        '{"dsp": null}',  # valid JSON, wrong shape for the model
+        '{"dsp": {"player_id": "abc123", "preamp_db": "loud"}}',  # valid JSON, wrong field type
+    ],
+)
+def test_dsp_get_raises_storage_error_on_wrong_shape_file(audera_home, content):
+    _write_raw('abc123', content)
     with pytest.raises(StorageError):
         dsp_dal.get('abc123')
 

--- a/tests/dal/test_settings.py
+++ b/tests/dal/test_settings.py
@@ -17,6 +17,15 @@ def _write_corrupt() -> str:
     return file_path
 
 
+def _write_raw(content: str) -> str:
+    """Writes arbitrary content to the settings file and returns its path."""
+    os.makedirs(settings_dal.PATH, exist_ok=True)
+    file_path = os.path.join(settings_dal.PATH, settings_dal.FILE_NAME)
+    with open(file_path, 'w') as f:
+        f.write(content)
+    return file_path
+
+
 def _settings(features: dict | None = None) -> Settings:
     return Settings(plexamp_host='localhost', snapserver_host='localhost', features=features or {})
 
@@ -90,6 +99,20 @@ def test_settings_load_without_features_key_backward_compatible(audera_home):
 
 def test_settings_get_raises_storage_error_on_corrupt_file(audera_home):
     _write_corrupt()
+    with pytest.raises(StorageError):
+        settings_dal.get()
+
+
+@pytest.mark.parametrize(
+    'content',
+    [
+        '{"other": {}}',  # valid JSON, missing the 'settings' key
+        '{"settings": null}',  # valid JSON, wrong shape for the model
+        '{"settings": {"plexamp_host": 5}}',  # valid JSON, wrong field type
+    ],
+)
+def test_settings_get_raises_storage_error_on_wrong_shape_file(audera_home, content):
+    _write_raw(content)
     with pytest.raises(StorageError):
         settings_dal.get()
 

--- a/tests/ui/test_streamer.py
+++ b/tests/ui/test_streamer.py
@@ -15,6 +15,7 @@ from nicegui.testing import User
 import audera.ui.streamer.pages._plex as streamer_plex
 from audera.cli import conf
 from audera.clients import CamillaDSPClient, SnapserverClient
+from audera.dal import balance as balance_dal
 from audera.dal import dsp as dsp_dal
 from audera.dal import presets as presets_dal
 from audera.dal import settings as settings_dal
@@ -22,6 +23,7 @@ from audera.dal import sources as sources_dal
 from audera.dal import volume as volume_dal
 from audera.domains.sources import CATALOG, SourceDefinition, default_source
 from audera.errors import ServiceError, Unreachable
+from audera.models.balance import ReferenceBalance
 from audera.models.dsp import Band, DSPConfig, Preset
 from audera.models.player import Group, Player
 from audera.models.settings import Settings
@@ -2068,6 +2070,92 @@ async def test_settings_first_load_seeds_default_features(audera_home, mock_snap
     Page().load()
     await user.open('/')
     assert settings_dal.get().features == features.default_selections()
+
+
+async def test_settings_tab_restore_disabled_until_a_balance_is_saved(audera_home, mock_snapserver_two_players, user: User):
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    assert not user.find(kind=ui.button, marker='restore-reference').elements.pop().enabled
+
+
+async def test_settings_tab_save_reference_balance_captures_current_volumes(
+    audera_home, mock_snapserver_two_players, user: User
+):
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    user.find(marker='save-reference').click()
+    await _settled(balance_dal.exists)
+    assert balance_dal.get().volumes == {'abc123': 80, 'def456': 80}
+
+
+async def test_settings_tab_save_enables_restore(audera_home, mock_snapserver_two_players, user: User):
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    user.find(marker='save-reference').click()
+    await _settled(lambda: user.find(kind=ui.button, marker='restore-reference').elements.pop().enabled)
+    assert user.find(kind=ui.button, marker='restore-reference').elements.pop().enabled
+
+
+async def test_settings_tab_restore_applies_to_connected_players_and_skips_the_rest(
+    audera_home, mock_snapserver_two_players, mock_camilladsp, monkeypatch, user: User
+):
+    """`ghost` is absent from the cache (never restored) and `def456` is absent from the saved
+    balance (skipped); only the connected, named `abc123` is written back."""
+    balance_dal.save(ReferenceBalance(volumes={'abc123': 30, 'ghost': 55}))
+
+    applied: list[tuple[str, int, bool]] = []
+
+    def _set_client_volume(self, client_id: str, percent: int, muted: bool = False):
+        applied.append((client_id, percent, muted))
+
+    monkeypatch.setattr(SnapserverClient, 'set_client_volume', _set_client_volume)
+
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    user.find(marker='restore-reference').click()
+    await _settled(lambda: bool(applied))
+    assert applied == [('abc123', 100, False)]
+    assert mock_camilladsp.get('set_percent_volume') == 30
+    assert volume_dal.get('abc123') == 30
+
+
+async def test_settings_tab_indicator_lights_when_players_match_the_reference(
+    audera_home, mock_snapserver_two_players, user: User
+):
+    balance_dal.save(ReferenceBalance(volumes={'abc123': 80, 'def456': 80}))
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    await user.should_see('Listening at reference')
+
+
+async def test_settings_tab_indicator_dark_when_a_player_diverges(audera_home, mock_snapserver_two_players, user: User):
+    balance_dal.save(ReferenceBalance(volumes={'abc123': 80, 'def456': 80}))
+    broker.get().cache.volumes['abc123'] = 55
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    await user.should_not_see('Listening at reference')
+
+
+async def test_settings_tab_indicator_dark_without_a_saved_reference(audera_home, mock_snapserver_two_players, user: User):
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    await user.should_not_see('Listening at reference')
+
+
+async def test_settings_tab_save_lights_the_indicator(audera_home, mock_snapserver_two_players, user: User):
+    Page().load()
+    await user.open('/')
+    user.find('Settings').click()
+    await user.should_not_see('Listening at reference')
+    user.find(marker='save-reference').click()
+    await user.should_see('Listening at reference')
 
 
 async def test_run_preamble_does_not_set_script_mode(audera_home, monkeypatch, user: User):

--- a/tests/ui/test_streamer_fanout.py
+++ b/tests/ui/test_streamer_fanout.py
@@ -4,7 +4,15 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import audera.ui.streamer as streamer
+from audera.dal import volume as volume_dal
 from audera.ui.streamer import broker as broker_mod
+
+
+class _InlineLoop:
+    """Fake event loop whose ``call_soon_threadsafe`` runs the callback inline."""
+
+    def call_soon_threadsafe(self, fn):
+        fn()
 
 
 def _page(*, dialog_open: bool = False):
@@ -13,9 +21,11 @@ def _page(*, dialog_open: bool = False):
         _deferred_tabs=set(),
         _build_players_tab=MagicMock(),
         _build_sources_tab=MagicMock(),
+        _build_settings_tab=MagicMock(),
     )
     page._build_players_tab.refresh = MagicMock()
     page._build_sources_tab.refresh = MagicMock()
+    page._build_settings_tab.refresh = MagicMock()
     return page
 
 
@@ -28,15 +38,18 @@ def test_on_dirty_refreshes_sources_only_when_stream_status_changes(monkeypatch)
     page = _page()
     monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
 
-    # Volume-only dirty: stream map unchanged.
+    # Volume-only dirty: stream map unchanged. Players and Settings still rebuild.
     streamer._on_dirty()
     page._build_players_tab.refresh.assert_called_once()
+    page._build_settings_tab.refresh.assert_called_once()
     page._build_sources_tab.refresh.assert_not_called()
 
     page._build_players_tab.refresh.reset_mock()
+    page._build_settings_tab.refresh.reset_mock()
     b.cache.stream_status = {'AirPlay': 'idle', 'Spotify': 'idle'}
     streamer._on_dirty()
     page._build_players_tab.refresh.assert_called_once()
+    page._build_settings_tab.refresh.assert_called_once()
     page._build_sources_tab.refresh.assert_called_once()
     assert streamer._prev_stream_status == (('AirPlay', 'idle'), ('Spotify', 'idle'))
 
@@ -53,4 +66,65 @@ def test_on_dirty_defers_sources_when_dialog_open(monkeypatch):
     streamer._on_dirty()
     page._build_players_tab.refresh.assert_not_called()
     page._build_sources_tab.refresh.assert_not_called()
-    assert page._deferred_tabs == {'players', 'sources'}
+    page._build_settings_tab.refresh.assert_not_called()
+    assert page._deferred_tabs == {'players', 'sources', 'settings'}
+
+
+def test_on_balance_changed_refreshes_settings_on_every_page(monkeypatch):
+    monkeypatch.setattr(streamer, '_loop', _InlineLoop())
+    page = _page()
+    monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
+
+    streamer._on_balance_changed()
+    page._build_settings_tab.refresh.assert_called_once()
+    page._build_players_tab.refresh.assert_not_called()
+    page._build_sources_tab.refresh.assert_not_called()
+
+
+def test_on_balance_changed_defers_settings_when_dialog_open(monkeypatch):
+    monkeypatch.setattr(streamer, '_loop', _InlineLoop())
+    page = _page(dialog_open=True)
+    monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
+
+    streamer._on_balance_changed()
+    page._build_settings_tab.refresh.assert_not_called()
+    assert page._deferred_tabs == {'settings'}
+
+
+def test_on_balance_changed_noop_without_loop(monkeypatch):
+    monkeypatch.setattr(streamer, '_loop', None)
+    page = _page()
+    monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
+
+    streamer._on_balance_changed()
+    page._build_settings_tab.refresh.assert_not_called()
+
+
+def test_on_volume_changed_pushes_cache_and_refreshes_settings(monkeypatch):
+    b = broker_mod.EventBroker('127.0.0.1', 1780)
+    monkeypatch.setattr(broker_mod, '_broker', b)
+    monkeypatch.setattr(streamer, '_loop', _InlineLoop())
+    monkeypatch.setattr(volume_dal, 'get_all', lambda: {'player-1': 50})
+
+    page = _page()
+    monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
+
+    streamer._on_volume_changed()
+    assert b.cache.volumes['player-1'] == 50
+    page._build_settings_tab.refresh.assert_called_once()
+    page._build_players_tab.refresh.assert_not_called()
+
+
+def test_on_volume_changed_defers_settings_when_dialog_open(monkeypatch):
+    b = broker_mod.EventBroker('127.0.0.1', 1780)
+    monkeypatch.setattr(broker_mod, '_broker', b)
+    monkeypatch.setattr(streamer, '_loop', _InlineLoop())
+    monkeypatch.setattr(volume_dal, 'get_all', lambda: {'player-1': 50})
+
+    page = _page(dialog_open=True)
+    monkeypatch.setattr(streamer, 'connected_pages', lambda: [(MagicMock(), page)])
+
+    streamer._on_volume_changed()
+    assert b.cache.volumes['player-1'] == 50
+    page._build_settings_tab.refresh.assert_not_called()
+    assert page._deferred_tabs == {'settings'}


### PR DESCRIPTION
Closes #57.

Adds the minimal "listening profiles" feature: after tuning per-player volumes so rooms match, save that balance as a single reference and restore it any time a listener has bumped a player off. This PR carries two commits — the feature, then a follow-up hardening the config-DAL read guards it surfaced.

## Feature — reference balance (commit `74653ec`)

### Model + DAL
- `models/balance.py` and `dal/balance.py`: a single-document JSON snapshot under `~/.audera/balance.json` (`save` overwrites, `get` re-reads), registered in `dal/__init__.py`. Mirrors the `settings` DAL idiom, atomic writes via `io.write_text`.

### Write path
- Extracted the volume write triad into `_apply_volume` (CamillaDSP → volume DAL → Snapcast 0/100 mute sidecar) so the slider and Save/Restore share one code path and never drift.

### Settings tab UI
A new "Reference balance" group at the top of the Settings tab:
- `Save` snapshots the current balance across all connected players.
- `Restore` re-applies it to connected players only (disconnected/absent players are skipped; the notification reports how many were restored). Disabled until a balance is saved.
- A live `● Listening at reference` indicator, left-anchored with the buttons anchored right on one fixed-height row; lights only when every connected player sits at its recorded reference.

### Freshness across clients — ADR 005 §10
The reference balance is a UI-visible write, so it follows the invariant in ADR 005 §10 ("fan out every UI-visible write") rather than a local `refresh()`:
- `dal/balance.py` exposes the observer pattern (`on_change` / `_notify_observers`, fired at the end of `save`).
- `streamer/__init__.py` adds `_on_balance_changed`, which marshals onto the UI loop and refreshes the **Settings** tab on every connected page (a save changes no volumes, so only Settings — its Restore button and indicator — needs to rebuild). It honors `page._dialog_open` / `_deferred_tabs` like every other observer (ADR 005 §7).
- `_on_dirty` now also refreshes the **Settings** tab on every broker dirty, and `_on_volume_changed` refreshes **Settings** too, so the indicator tracks connection changes and loudness changes that cross no Snapcast mute boundary (which produce no broker dirty).
- ADR 005 §7 and §10, and `audera/ui/AGENTS.md`, are updated to name the balance observer and restate the invariant.

### Scope decisions
Single reference balance (Save overwrites, Restore re-applies), one correct UX per `audera/ui/AGENTS.md`'s UX-optionality rule, so no `features.py` entry.

## Follow-up — config-DAL read guards (commit `6d44e28`)

Code review of the feature surfaced a latent gap the balance DAL inherited from its `settings`/`dsp` siblings: the single-document `get()` methods wrapped only `json.load` in their `StorageError` guard, leaving `data['<key>']` and `model_validate(...)` outside it. A file that was valid JSON but missing the expected key or off the model's shape leaked a raw `KeyError`/`ValidationError` past every caller's `except CommandError` — which, for balance, would throw on every Settings render (`_at_reference` runs on each dirty and volume change) and defeat the `get_or_create` "return seed without rewriting" degrade path.

Fixed across all three single-document DALs (`balance`, `settings`, `dsp`):
- Pulled the key access and validation inside the `try` and widened the catch to `(OSError, ValueError, KeyError, ValidationError)`, so any corruption shape becomes `StorageError` — the contract each `get()` docstring already promised.
- Collection/optional DALs (`volume`, `presets`, `sources`) were left untouched: they already swallow all corruption by design and never raise.

## Tests
- `tests/dal/test_balance.py`: round-trip, `exists()` transitions, overwrite, MAC-keyed ids, empty snapshot, corrupt-file → `StorageError`, and wrong-shape files (missing key / null / wrong field type) → `StorageError`.
- `tests/dal/test_settings.py`, `tests/dal/test_dsp.py`: matching wrong-shape → `StorageError` coverage alongside the existing unparseable-JSON tests.
- `tests/ui/test_streamer.py`: Save captures cache volumes; Restore applies per connected player and skips disconnected/absent; Restore disabled until saved; indicator lights/darkens across states.
- `tests/ui/test_streamer_fanout.py`: Settings refreshes on every dirty; deferral when a dialog is open.

## Verification
- `uv run ruff check --fix && uv run ruff format && uv run ty check` — clean
- `uv run pytest tests/dal/ tests/ui/test_streamer.py tests/ui/test_streamer_fanout.py` — all passing
- Manual off-device via `audera streamer start --mock` against a live device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
